### PR TITLE
전남대 최지민 Step3 위시리스트 구현 

### DIFF
--- a/src/main/java/gift/config/GlobalExceptionHandler.java
+++ b/src/main/java/gift/config/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import gift.dto.ErrorResponse;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -47,6 +48,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateKeyException.class)
     public ResponseEntity<ErrorResponse> handleMissingHeader(DuplicateKeyException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> beanValidationError(MethodArgumentNotValidException ex) {
         ErrorResponse response = new ErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED.value());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/gift/config/JwtTokenProvider.java
+++ b/src/main/java/gift/config/JwtTokenProvider.java
@@ -37,4 +37,13 @@ public class JwtTokenProvider {
             return false;
         }
     }
+
+    public String getEmailFromToken(String token) {
+        return Jwts.parser()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
 }

--- a/src/main/java/gift/config/LoginCheckInterceptor.java
+++ b/src/main/java/gift/config/LoginCheckInterceptor.java
@@ -2,6 +2,7 @@ package gift.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -15,11 +16,12 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        String authHeader = request.getHeader("Authorization");
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (!jwtTokenProvider.validateToken(authHeader)) {
             throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
         }
+        request.setAttribute("userEmail", jwtTokenProvider.getEmailFromToken(authHeader.substring(7)));
         return true;
     }
 }

--- a/src/main/java/gift/config/LoginCheckInterceptor.java
+++ b/src/main/java/gift/config/LoginCheckInterceptor.java
@@ -1,0 +1,25 @@
+package gift.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginCheckInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authHeader = request.getHeader("Authorization");
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,16 +1,22 @@
 package gift.config;
 
+import gift.login.LoginArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginCheckInterceptor loginCheckInterceptor;
+    private final LoginArgumentResolver loginArgumentResolver;
 
-    public WebConfig(LoginCheckInterceptor loginCheckInterceptor) {
+    public WebConfig(LoginCheckInterceptor loginCheckInterceptor, LoginArgumentResolver loginArgumentResolver) {
         this.loginCheckInterceptor = loginCheckInterceptor;
+        this.loginArgumentResolver = loginArgumentResolver;
     }
 
     @Override
@@ -21,5 +27,11 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/wishes/**",
                         "/css/**", "/*.ico", "/error"
                 );
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginArgumentResolver);
+        WebMvcConfigurer.super.addArgumentResolvers(resolvers);
     }
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,0 +1,25 @@
+package gift.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginCheckInterceptor loginCheckInterceptor;
+
+    public WebConfig(LoginCheckInterceptor loginCheckInterceptor) {
+        this.loginCheckInterceptor = loginCheckInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginCheckInterceptor)
+                .order(1)
+                .addPathPatterns(
+                        "/api/wishes/**",
+                        "/css/**", "/*.ico", "/error"
+                );
+    }
+}

--- a/src/main/java/gift/controller/MemberRestController.java
+++ b/src/main/java/gift/controller/MemberRestController.java
@@ -1,12 +1,7 @@
 package gift.controller;
 
 import gift.config.JwtTokenProvider;
-import gift.config.UnAuthorizationException;
-import gift.domain.Product;
-import gift.dto.CreateMemberRequest;
-import gift.dto.CreateMemberResponse;
-import gift.dto.LoginMemberRequest;
-import gift.dto.LoginMemberResponse;
+import gift.dto.*;
 import gift.service.MemberService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -42,12 +37,4 @@ public class MemberRestController {
         return new ResponseEntity<>(new LoginMemberResponse(token), HttpStatus.OK);
     }
 
-    @GetMapping("/products")
-    public HttpEntity<List<Product>> getProducts(@RequestHeader("Authorization") String authHeader) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
-        List<Product> productList = service.productList();
-        return new ResponseEntity<>(productList, HttpStatus.OK);
-    }
 }

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -3,13 +3,12 @@ package gift.controller;
 import gift.config.JwtTokenProvider;
 import gift.config.UnAuthorizationException;
 import gift.domain.Product;
-import gift.dto.CreateWishRequest;
-import gift.dto.CreateWishResponse;
-import gift.dto.WishResponse;
+import gift.dto.*;
 import gift.service.WishService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,7 +35,7 @@ public class WishRestController {
     }
 
     @PostMapping()
-    public HttpEntity<CreateWishResponse> addWishList(@RequestBody CreateWishRequest request,
+    public HttpEntity<CreateWishResponse> addWishList(@Validated @RequestBody CreateWishRequest request,
                                                       @RequestHeader("Authorization") String authHeader) {
         if (!jwtTokenProvider.validateToken(authHeader)) {
             throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
@@ -61,5 +60,14 @@ public class WishRestController {
         }
         service.delete(wishId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping("/{wishId}")
+    HttpEntity<UpdateWishResponse> updateQuantity(@RequestHeader("Authorization") String authHeader, @Validated @RequestBody UpdateWishRequest request, @PathVariable Long wishId) {
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        UpdateWishResponse response = service.updateQuantity(request, wishId);
+        return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -4,6 +4,7 @@ import gift.config.JwtTokenProvider;
 import gift.config.UnAuthorizationException;
 import gift.domain.Product;
 import gift.dto.CreateWishRequest;
+import gift.dto.CreateWishResponse;
 import gift.dto.WishResponse;
 import gift.service.WishService;
 import org.springframework.http.HttpEntity;
@@ -35,13 +36,13 @@ public class WishRestController {
     }
 
     @PostMapping()
-    public HttpEntity<Void> addWishList(@RequestBody CreateWishRequest request,
-                                        @RequestHeader("Authorization") String authHeader) {
+    public HttpEntity<CreateWishResponse> addWishList(@RequestBody CreateWishRequest request,
+                                                      @RequestHeader("Authorization") String authHeader) {
         if (!jwtTokenProvider.validateToken(authHeader)) {
             throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
         }
-        service.addWishProduct(request);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        CreateWishResponse response = service.addWishProduct(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @GetMapping("/{memberId}")
@@ -51,5 +52,14 @@ public class WishRestController {
         }
         List<WishResponse> wishList = service.getMeberWishList(memberId);
         return new ResponseEntity<>(wishList, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{wishId}")
+    HttpEntity<Void> deleteProduct(@RequestHeader("Authorization") String authHeader, @PathVariable Long wishId) {
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        service.delete(wishId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -4,6 +4,7 @@ import gift.config.JwtTokenProvider;
 import gift.config.UnAuthorizationException;
 import gift.domain.Product;
 import gift.dto.CreateWishRequest;
+import gift.dto.WishResponse;
 import gift.service.WishService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -41,5 +42,14 @@ public class WishRestController {
         }
         service.addWishProduct(request);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/{memberId}")
+    public HttpEntity<List<WishResponse>> getWishList(@RequestHeader("Authorization") String authHeader, @PathVariable Long memberId) {
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        List<WishResponse> wishList = service.getMeberWishList(memberId);
+        return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 }

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -1,7 +1,5 @@
 package gift.controller;
 
-import gift.config.JwtTokenProvider;
-import gift.config.UnAuthorizationException;
 import gift.domain.Product;
 import gift.dto.*;
 import gift.service.WishService;
@@ -16,57 +14,39 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/wishes")
 public class WishRestController {
-    private final JwtTokenProvider jwtTokenProvider;
     private final WishService service;
 
 
-    public WishRestController(JwtTokenProvider jwtTokenProvider, WishService service) {
-        this.jwtTokenProvider = jwtTokenProvider;
+    public WishRestController(WishService service) {
         this.service = service;
     }
 
     @GetMapping("/products")
-    public HttpEntity<List<Product>> getProducts(@RequestHeader("Authorization") String authHeader) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
+    public HttpEntity<List<Product>> getProducts() {
         List<Product> productList = service.productList();
         return new ResponseEntity<>(productList, HttpStatus.OK);
     }
 
     @PostMapping()
-    public HttpEntity<CreateWishResponse> addWishList(@Validated @RequestBody CreateWishRequest request,
-                                                      @RequestHeader("Authorization") String authHeader) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
+    public HttpEntity<CreateWishResponse> addWishList(@Validated @RequestBody CreateWishRequest request) {
         CreateWishResponse response = service.addWishProduct(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @GetMapping("/{memberId}")
-    public HttpEntity<List<WishResponse>> getWishList(@RequestHeader("Authorization") String authHeader, @PathVariable Long memberId) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
+    public HttpEntity<List<WishResponse>> getWishList(@PathVariable Long memberId) {
         List<WishResponse> wishList = service.getMeberWishList(memberId);
         return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 
     @DeleteMapping("/{wishId}")
-    HttpEntity<Void> deleteProduct(@RequestHeader("Authorization") String authHeader, @PathVariable Long wishId) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
+    HttpEntity<Void> deleteProduct(@PathVariable Long wishId) {
         service.delete(wishId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @PatchMapping("/{wishId}")
-    HttpEntity<UpdateWishResponse> updateQuantity(@RequestHeader("Authorization") String authHeader, @Validated @RequestBody UpdateWishRequest request, @PathVariable Long wishId) {
-        if (!jwtTokenProvider.validateToken(authHeader)) {
-            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
-        }
+    HttpEntity<UpdateWishResponse> updateQuantity(@Validated @RequestBody UpdateWishRequest request, @PathVariable Long wishId) {
         UpdateWishResponse response = service.updateQuantity(request, wishId);
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -1,0 +1,45 @@
+package gift.controller;
+
+import gift.config.JwtTokenProvider;
+import gift.config.UnAuthorizationException;
+import gift.domain.Product;
+import gift.dto.CreateWishRequest;
+import gift.service.WishService;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/wishes")
+public class WishRestController {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final WishService service;
+
+
+    public WishRestController(JwtTokenProvider jwtTokenProvider, WishService service) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.service = service;
+    }
+
+    @GetMapping("/products")
+    public HttpEntity<List<Product>> getProducts(@RequestHeader("Authorization") String authHeader) {
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        List<Product> productList = service.productList();
+        return new ResponseEntity<>(productList, HttpStatus.OK);
+    }
+
+    @PostMapping()
+    public HttpEntity<Void> addWishList(@RequestBody CreateWishRequest request,
+                                        @RequestHeader("Authorization") String authHeader) {
+        if (!jwtTokenProvider.validateToken(authHeader)) {
+            throw new UnAuthorizationException("인증되지 않은 사용자입니다.");
+        }
+        service.addWishProduct(request);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/gift/controller/WishRestController.java
+++ b/src/main/java/gift/controller/WishRestController.java
@@ -2,6 +2,8 @@ package gift.controller;
 
 import gift.domain.Product;
 import gift.dto.*;
+import gift.login.Login;
+import gift.login.LoginMember;
 import gift.service.WishService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -28,26 +30,27 @@ public class WishRestController {
     }
 
     @PostMapping()
-    public HttpEntity<CreateWishResponse> addWishList(@Validated @RequestBody CreateWishRequest request) {
-        CreateWishResponse response = service.addWishProduct(request);
+    public HttpEntity<CreateWishResponse> addWishList(@Validated @RequestBody CreateWishRequest request,
+                                                      @Login LoginMember loginMember) {
+        CreateWishResponse response = service.addWishProduct(request, loginMember.id());
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @GetMapping("/{memberId}")
-    public HttpEntity<List<WishResponse>> getWishList(@PathVariable Long memberId) {
-        List<WishResponse> wishList = service.getMeberWishList(memberId);
+    @GetMapping
+    public HttpEntity<List<WishResponse>> getWishList(@Login LoginMember loginMember) {
+        List<WishResponse> wishList = service.getMeberWishList(loginMember.id());
         return new ResponseEntity<>(wishList, HttpStatus.OK);
     }
 
     @DeleteMapping("/{wishId}")
-    HttpEntity<Void> deleteProduct(@PathVariable Long wishId) {
-        service.delete(wishId);
+    HttpEntity<Void> deleteProduct(@PathVariable Long wishId, @Login LoginMember loginMember) {
+        service.delete(wishId, loginMember.id());
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @PatchMapping("/{wishId}")
-    HttpEntity<UpdateWishResponse> updateQuantity(@Validated @RequestBody UpdateWishRequest request, @PathVariable Long wishId) {
-        UpdateWishResponse response = service.updateQuantity(request, wishId);
+    HttpEntity<UpdateWishResponse> updateQuantity(@Validated @RequestBody UpdateWishRequest request, @PathVariable Long wishId, @Login LoginMember loginMember) {
+        UpdateWishResponse response = service.updateQuantity(request, wishId, loginMember.id());
         return new ResponseEntity<>(response, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/gift/domain/Wish.java
+++ b/src/main/java/gift/domain/Wish.java
@@ -1,0 +1,32 @@
+package gift.domain;
+
+public class Wish {
+
+    private final Long id;
+    private final Long memberId;
+    private final Long productId;
+    private final int quantity;
+
+    public Wish(Long id, Long memberId, Long productId, int quantity) {
+        this.id = id;
+        this.memberId = memberId;
+        this.productId = productId;
+        this.quantity = quantity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+}

--- a/src/main/java/gift/dto/CreateWishRequest.java
+++ b/src/main/java/gift/dto/CreateWishRequest.java
@@ -1,0 +1,4 @@
+package gift.dto;
+
+public record CreateWishRequest(Long memberId, Long productId, int quantity) {
+}

--- a/src/main/java/gift/dto/CreateWishRequest.java
+++ b/src/main/java/gift/dto/CreateWishRequest.java
@@ -1,6 +1,7 @@
 package gift.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-public record CreateWishRequest(Long memberId, Long productId, @Positive(message = "수량은 0보다 커야합니다.") int quantity) {
+public record CreateWishRequest(@NotNull Long productId, @Positive(message = "수량은 0보다 커야합니다.") int quantity) {
 }

--- a/src/main/java/gift/dto/CreateWishRequest.java
+++ b/src/main/java/gift/dto/CreateWishRequest.java
@@ -1,4 +1,6 @@
 package gift.dto;
 
-public record CreateWishRequest(Long memberId, Long productId, int quantity) {
+import jakarta.validation.constraints.Positive;
+
+public record CreateWishRequest(Long memberId, Long productId, @Positive(message = "수량은 0보다 커야합니다.") int quantity) {
 }

--- a/src/main/java/gift/dto/CreateWishResponse.java
+++ b/src/main/java/gift/dto/CreateWishResponse.java
@@ -1,0 +1,4 @@
+package gift.dto;
+
+public record CreateWishResponse(Long id, Long memberId, Long productId, int quantity) {
+}

--- a/src/main/java/gift/dto/UpdateWishRequest.java
+++ b/src/main/java/gift/dto/UpdateWishRequest.java
@@ -1,0 +1,6 @@
+package gift.dto;
+
+import jakarta.validation.constraints.Positive;
+
+public record UpdateWishRequest (@Positive(message = "수량은 0보다 커야 합니다.") int quantity){
+}

--- a/src/main/java/gift/dto/UpdateWishResponse.java
+++ b/src/main/java/gift/dto/UpdateWishResponse.java
@@ -1,0 +1,4 @@
+package gift.dto;
+
+public record UpdateWishResponse (Long id, Long productId, int quantity) {
+}

--- a/src/main/java/gift/dto/WishResponse.java
+++ b/src/main/java/gift/dto/WishResponse.java
@@ -1,0 +1,4 @@
+package gift.dto;
+
+public record WishResponse(Long id, String productName, int price, int quantity) {
+}

--- a/src/main/java/gift/login/Login.java
+++ b/src/main/java/gift/login/Login.java
@@ -1,0 +1,11 @@
+package gift.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Login {
+}

--- a/src/main/java/gift/login/LoginArgumentResolver.java
+++ b/src/main/java/gift/login/LoginArgumentResolver.java
@@ -1,0 +1,39 @@
+package gift.login;
+
+import gift.domain.Member;
+import gift.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.NoSuchElementException;
+
+
+@Component
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    public LoginArgumentResolver(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Login.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String userEmail = (String) request.getAttribute("userEmail");
+
+        Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new NoSuchElementException("등록되지 않은 사용자입니다."));
+        return new LoginMember(member.getId(), member.getEmail());
+    }
+}

--- a/src/main/java/gift/login/LoginMember.java
+++ b/src/main/java/gift/login/LoginMember.java
@@ -1,0 +1,4 @@
+package gift.login;
+
+public record LoginMember(Long id, String email) {
+}

--- a/src/main/java/gift/repository/WishJdbcRepository.java
+++ b/src/main/java/gift/repository/WishJdbcRepository.java
@@ -1,10 +1,8 @@
 package gift.repository;
 
 import gift.domain.Wish;
-import gift.dto.CreateWishRequest;
-import gift.dto.UpdateWishRequest;
 import gift.dto.WishResponse;
-import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
@@ -27,10 +25,13 @@ public class WishJdbcRepository implements WishRepository {
     }
 
     @Override
-    public Wish save(CreateWishRequest request) {
-        BeanPropertySqlParameterSource param = new BeanPropertySqlParameterSource(request);
+    public Wish save(Long productId, Long memberId, int quantity) {
+        MapSqlParameterSource param = new MapSqlParameterSource()
+                .addValue("product_id", productId)
+                .addValue("member_id", memberId)
+                .addValue("quantity", quantity);
         Number key = jdbcInsert.executeAndReturnKey(param);
-        return new Wish(key.longValue(), request.memberId(), request.productId(), request.quantity());
+        return new Wish(key.longValue(), memberId, productId, quantity);
     }
 
     @Override
@@ -56,10 +57,10 @@ public class WishJdbcRepository implements WishRepository {
     }
 
     @Override
-    public void update(UpdateWishRequest request, Long wishId) {
+    public void update(int quantity, Long wishId) {
         String sql = "update wish set quantity = :quantity where id = :id";
         client.sql(sql)
-                .param("quantity", request.quantity())
+                .param("quantity", quantity)
                 .param("id", wishId)
                 .update();
     }

--- a/src/main/java/gift/repository/WishJdbcRepository.java
+++ b/src/main/java/gift/repository/WishJdbcRepository.java
@@ -2,6 +2,7 @@ package gift.repository;
 
 import gift.domain.Wish;
 import gift.dto.CreateWishRequest;
+import gift.dto.UpdateWishRequest;
 import gift.dto.WishResponse;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -52,6 +53,15 @@ public class WishJdbcRepository implements WishRepository {
                 .param("id", memberId)
                 .query(WishResponse.class)
                 .list();
+    }
+
+    @Override
+    public void update(UpdateWishRequest request, Long wishId) {
+        String sql = "update wish set quantity = :quantity where id = :id";
+        client.sql(sql)
+                .param("quantity", request.quantity())
+                .param("id", wishId)
+                .update();
     }
 
     @Override

--- a/src/main/java/gift/repository/WishJdbcRepository.java
+++ b/src/main/java/gift/repository/WishJdbcRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class WishJdbcRepository implements WishRepository {
@@ -32,6 +33,15 @@ public class WishJdbcRepository implements WishRepository {
     }
 
     @Override
+    public Optional<Wish> findById(Long id) {
+        String sql = "select * from wish where id = :id";
+        return client.sql(sql)
+                .param("id", id)
+                .query(Wish.class)
+                .optional();
+    }
+
+    @Override
     public List<WishResponse> findAllByMember(Long memberId) {
         String sql = "select wish.id, product.name as productName, product.price, wish.quantity " +
                 "from wish " +
@@ -42,5 +52,13 @@ public class WishJdbcRepository implements WishRepository {
                 .param("id", memberId)
                 .query(WishResponse.class)
                 .list();
+    }
+
+    @Override
+    public void delete(Long wishId) {
+        String sql = "delete from wish where id = :wishId";
+        client.sql(sql)
+                .param("wishId", wishId)
+                .update();
     }
 }

--- a/src/main/java/gift/repository/WishJdbcRepository.java
+++ b/src/main/java/gift/repository/WishJdbcRepository.java
@@ -1,0 +1,32 @@
+package gift.repository;
+
+import gift.domain.Wish;
+import gift.dto.CreateWishRequest;
+import gift.dto.CreateWishResponse;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+
+@Repository
+public class WishJdbcRepository implements WishRepository {
+
+    private final JdbcClient client;
+    private final SimpleJdbcInsert jdbcInsert;
+
+    public WishJdbcRepository(DataSource dataSource) {
+        this.client = JdbcClient.create(dataSource);
+        this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+                .withTableName("wish")
+                .usingGeneratedKeyColumns("id");
+    }
+
+    @Override
+    public Wish save(CreateWishRequest request) {
+        BeanPropertySqlParameterSource param = new BeanPropertySqlParameterSource(request);
+        Number key = jdbcInsert.executeAndReturnKey(param);
+        return new Wish(key.longValue(), request.memberId(), request.productId(), request.quantity());
+    }
+}

--- a/src/main/java/gift/repository/WishJdbcRepository.java
+++ b/src/main/java/gift/repository/WishJdbcRepository.java
@@ -2,13 +2,14 @@ package gift.repository;
 
 import gift.domain.Wish;
 import gift.dto.CreateWishRequest;
-import gift.dto.CreateWishResponse;
+import gift.dto.WishResponse;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.List;
 
 @Repository
 public class WishJdbcRepository implements WishRepository {
@@ -28,5 +29,18 @@ public class WishJdbcRepository implements WishRepository {
         BeanPropertySqlParameterSource param = new BeanPropertySqlParameterSource(request);
         Number key = jdbcInsert.executeAndReturnKey(param);
         return new Wish(key.longValue(), request.memberId(), request.productId(), request.quantity());
+    }
+
+    @Override
+    public List<WishResponse> findAllByMember(Long memberId) {
+        String sql = "select wish.id, product.name as productName, product.price, wish.quantity " +
+                "from wish " +
+                "join product on wish.product_id = product.id " +
+                "join member on wish.member_id = member.id " +
+                "where member.id = :id";
+        return client.sql(sql)
+                .param("id", memberId)
+                .query(WishResponse.class)
+                .list();
     }
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -2,6 +2,7 @@ package gift.repository;
 
 import gift.domain.Wish;
 import gift.dto.CreateWishRequest;
+import gift.dto.UpdateWishRequest;
 import gift.dto.WishResponse;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface WishRepository {
     void delete(Long wishId);
 
     Optional<Wish> findById(Long id);
+
+    void update(UpdateWishRequest request, Long wishId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,8 +1,6 @@
 package gift.repository;
 
 import gift.domain.Wish;
-import gift.dto.CreateWishRequest;
-import gift.dto.UpdateWishRequest;
 import gift.dto.WishResponse;
 
 import java.util.List;
@@ -10,7 +8,7 @@ import java.util.Optional;
 
 public interface WishRepository {
 
-    Wish save(CreateWishRequest request);
+    Wish save(Long productId, Long memberId, int quantity);
 
     List<WishResponse> findAllByMember(Long memberId);
 
@@ -18,5 +16,5 @@ public interface WishRepository {
 
     Optional<Wish> findById(Long id);
 
-    void update(UpdateWishRequest request, Long wishId);
+    void update(int quantity, Long wishId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -2,8 +2,13 @@ package gift.repository;
 
 import gift.domain.Wish;
 import gift.dto.CreateWishRequest;
+import gift.dto.WishResponse;
+
+import java.util.List;
 
 public interface WishRepository {
 
     Wish save(CreateWishRequest request);
+
+    List<WishResponse> findAllByMember(Long memberId);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -5,10 +5,15 @@ import gift.dto.CreateWishRequest;
 import gift.dto.WishResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WishRepository {
 
     Wish save(CreateWishRequest request);
 
     List<WishResponse> findAllByMember(Long memberId);
+
+    void delete(Long wishId);
+
+    Optional<Wish> findById(Long id);
 }

--- a/src/main/java/gift/repository/WishRepository.java
+++ b/src/main/java/gift/repository/WishRepository.java
@@ -1,0 +1,9 @@
+package gift.repository;
+
+import gift.domain.Wish;
+import gift.dto.CreateWishRequest;
+
+public interface WishRepository {
+
+    Wish save(CreateWishRequest request);
+}

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -2,21 +2,26 @@ package gift.service;
 
 import gift.domain.Product;
 import gift.dto.CreateWishRequest;
+import gift.dto.WishResponse;
+import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class WishService {
 
     private final ProductRepository productRepository;
     private final WishRepository wishRepository;
+    private final MemberRepository memberRepository;
 
-    public WishService(ProductRepository productRepository, WishRepository wishRestController) {
+    public WishService(ProductRepository productRepository, WishRepository wishRestController, MemberRepository memberRepository) {
         this.productRepository = productRepository;
         this.wishRepository = wishRestController;
+        this.memberRepository = memberRepository;
     }
 
     public List<Product> productList() {
@@ -25,5 +30,12 @@ public class WishService {
 
     public void addWishProduct(CreateWishRequest request) {
         wishRepository.save(request);
+    }
+
+    public List<WishResponse> getMeberWishList(Long memberId) {
+        if (memberRepository.findById(memberId).isEmpty()) {
+            throw new NoSuchElementException("존재하지 않는 멤버입니다.");
+        }
+        return wishRepository.findAllByMember(memberId);
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,7 +1,9 @@
 package gift.service;
 
 import gift.domain.Product;
+import gift.domain.Wish;
 import gift.dto.CreateWishRequest;
+import gift.dto.CreateWishResponse;
 import gift.dto.WishResponse;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
@@ -28,14 +30,30 @@ public class WishService {
         return productRepository.findAll();
     }
 
-    public void addWishProduct(CreateWishRequest request) {
-        wishRepository.save(request);
+    public CreateWishResponse addWishProduct(CreateWishRequest request) {
+        Wish wish = wishRepository.save(request);
+        return new CreateWishResponse(wish.getId(), wish.getMemberId(), wish.getProductId(), wish.getQuantity());
     }
 
     public List<WishResponse> getMeberWishList(Long memberId) {
+        findMemberOrThrow(memberId);
+        return wishRepository.findAllByMember(memberId);
+    }
+
+    public void delete(Long wishId) {
+        findByIdOrThrow(wishId);
+        wishRepository.delete(wishId);
+    }
+
+    private void findByIdOrThrow(Long wishId) {
+        if (wishRepository.findById(wishId).isEmpty()) {
+            throw new NoSuchElementException("존재하지 않는 위시리스트 상품입니다.");
+        }
+    }
+
+    private void findMemberOrThrow(Long memberId) {
         if (memberRepository.findById(memberId).isEmpty()) {
             throw new NoSuchElementException("존재하지 않는 멤버입니다.");
         }
-        return wishRepository.findAllByMember(memberId);
     }
 }

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,0 +1,29 @@
+package gift.service;
+
+import gift.domain.Product;
+import gift.dto.CreateWishRequest;
+import gift.repository.ProductRepository;
+import gift.repository.WishRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class WishService {
+
+    private final ProductRepository productRepository;
+    private final WishRepository wishRepository;
+
+    public WishService(ProductRepository productRepository, WishRepository wishRestController) {
+        this.productRepository = productRepository;
+        this.wishRepository = wishRestController;
+    }
+
+    public List<Product> productList() {
+        return productRepository.findAll();
+    }
+
+    public void addWishProduct(CreateWishRequest request) {
+        wishRepository.save(request);
+    }
+}

--- a/src/main/java/gift/service/WishService.java
+++ b/src/main/java/gift/service/WishService.java
@@ -1,10 +1,9 @@
 package gift.service;
 
+import gift.domain.Member;
 import gift.domain.Product;
 import gift.domain.Wish;
-import gift.dto.CreateWishRequest;
-import gift.dto.CreateWishResponse;
-import gift.dto.WishResponse;
+import gift.dto.*;
 import gift.repository.MemberRepository;
 import gift.repository.ProductRepository;
 import gift.repository.WishRepository;
@@ -12,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 public class WishService {
@@ -45,15 +45,25 @@ public class WishService {
         wishRepository.delete(wishId);
     }
 
-    private void findByIdOrThrow(Long wishId) {
-        if (wishRepository.findById(wishId).isEmpty()) {
-            throw new NoSuchElementException("존재하지 않는 위시리스트 상품입니다.");
-        }
+    public UpdateWishResponse updateQuantity(UpdateWishRequest request, Long wishId) {
+        Wish wishProduct = findByIdOrThrow(wishId);
+        wishRepository.update(request, wishId);
+        return new UpdateWishResponse(wishProduct.getId(), wishProduct.getProductId(), request.quantity());
     }
 
-    private void findMemberOrThrow(Long memberId) {
-        if (memberRepository.findById(memberId).isEmpty()) {
+    private Wish findByIdOrThrow(Long wishId) {
+        Optional<Wish> findWishProduct = wishRepository.findById(wishId);
+        if (findWishProduct.isEmpty()) {
+            throw new NoSuchElementException("존재하지 않는 위시리스트 상품입니다.");
+        }
+        return findWishProduct.get();
+    }
+
+    private Member findMemberOrThrow(Long memberId) {
+        Optional<Member> findMember = memberRepository.findById(memberId);
+        if (findMember.isEmpty()) {
             throw new NoSuchElementException("존재하지 않는 멤버입니다.");
         }
+        return findMember.get();
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -21,6 +21,7 @@ create table wish
    id bigint auto_increment,
     member_id bigint,
     product_id bigint,
+    quantity bigint,
    primary key (id),
     foreign key (member_id) references member,
     foreign key (product_id) references product

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -16,3 +16,13 @@ create table member
    primary key (id)
 );
 
+create table wish
+(
+   id bigint auto_increment,
+    member_id bigint,
+    product_id bigint,
+   primary key (id),
+    foreign key (member_id) references member,
+    foreign key (product_id) references product
+);
+

--- a/src/test/java/gift/controller/MemberRestControllerTest.java
+++ b/src/test/java/gift/controller/MemberRestControllerTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.*;
 @Sql(statements = "delete from member")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MemberRestControllerTest {
+
     @LocalServerPort
     private int port;
-
     private RestClient client = RestClient.create();
 
 
@@ -108,37 +108,5 @@ class MemberRestControllerTest {
                         .retrieve()
                         .toEntity(LoginMemberResponse.class)
         ).isInstanceOf(HttpClientErrorException.Unauthorized.class);
-    }
-
-    @Test
-    @DisplayName("로그인 멤버 상품 조회")
-    void getProducts() {
-        String url = "http://localhost:" + port + "/api/members/register";
-        ResponseEntity<CreateMemberResponse> registerResponse = client.post()
-                .uri(url)
-                .body(new CreateMemberRequest("test@exam.com", "1234"))
-                .retrieve()
-                .toEntity(CreateMemberResponse.class);
-
-        url = "http://localhost:" + port + "/api/members/login";
-        ResponseEntity<LoginMemberResponse> loginResponse = client.post()
-                .uri(url)
-                .body(new LoginMemberRequest("test@exam.com", "1234"))
-                .retrieve()
-                .toEntity(LoginMemberResponse.class);
-
-        String body = loginResponse.getBody().toString();
-        int start = body.indexOf("token=") + "token=".length();
-        int end = body.indexOf("]", start);
-        String token = body.substring(start, end);
-
-        url = "http://localhost:" + port + "/api/members/products";
-        ResponseEntity<Void> response = client.get()
-                .uri(url)
-                .header("Authorization", "Bearer " + token)
-                .retrieve()
-                .toBodilessEntity();
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/src/test/java/gift/controller/WishRestControllerTest.java
+++ b/src/test/java/gift/controller/WishRestControllerTest.java
@@ -1,0 +1,103 @@
+package gift.controller;
+
+import gift.dto.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql(statements = "delete from wish")
+@Sql(statements = "delete from member")
+@Sql(statements = "delete from product")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WishRestControllerTest {
+
+    @LocalServerPort
+    private int port;
+    private RestClient client = RestClient.create();
+
+    @Test
+    @DisplayName("로그인 멤버 상품 조회")
+    void getProducts() {
+        String url = "http://localhost:" + port + "/api/members/register";
+        ResponseEntity<CreateMemberResponse> registerResponse = client.post()
+                .uri(url)
+                .body(new CreateMemberRequest("test@exam.com", "1234"))
+                .retrieve()
+                .toEntity(CreateMemberResponse.class);
+
+        url = "http://localhost:" + port + "/api/members/login";
+        ResponseEntity<LoginMemberResponse> loginResponse = client.post()
+                .uri(url)
+                .body(new LoginMemberRequest("test@exam.com", "1234"))
+                .retrieve()
+                .toEntity(LoginMemberResponse.class);
+
+        String body = loginResponse.getBody().toString();
+        int start = body.indexOf("token=") + "token=".length();
+        int end = body.indexOf("]", start);
+        String token = body.substring(start, end);
+
+        url = "http://localhost:" + port + "/api/wishes/products";
+        ResponseEntity<Void> response = client.get()
+                .uri(url)
+                .header("Authorization", "Bearer " + token)
+                .retrieve()
+                .toBodilessEntity();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("위시 리스트에 상품 추가")
+    void 위시리스트_상품_추가() {
+        //상품 추가
+        String url = "http://localhost:" + port + "/api/products";
+        ResponseEntity<CreateProductResponse> productResponse = client.post()
+                .uri(url)
+                .body(new CreateProductRequest("product1", 1000, "exam.url"))
+                .retrieve()
+                .toEntity(CreateProductResponse.class);
+        assertThat(productResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        url = "http://localhost:" + port + "/api/members/register";
+
+        // 회원가입 및 로그인
+        ResponseEntity<CreateMemberResponse> registerResponse = client.post()
+                .uri(url)
+                .body(new CreateMemberRequest("test@exam.com", "1234"))
+                .retrieve()
+                .toEntity(CreateMemberResponse.class);
+
+        url = "http://localhost:" + port + "/api/members/login";
+        ResponseEntity<LoginMemberResponse> loginResponse = client.post()
+                .uri(url)
+                .body(new LoginMemberRequest("test@exam.com", "1234"))
+                .retrieve()
+                .toEntity(LoginMemberResponse.class);
+
+        String body = loginResponse.getBody().toString();
+        int start = body.indexOf("token=") + "token=".length();
+        int end = body.indexOf("]", start);
+        String token = body.substring(start, end);
+
+
+        //위시 리스트에 상품 추가
+        url = "http://localhost:" + port + "/api/wishes";
+        ResponseEntity<Void> response = client.post()
+                .uri(url)
+                .header("Authorization", "Bearer " + token)
+                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .retrieve()
+                .toBodilessEntity();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    }
+}

--- a/src/test/java/gift/controller/WishRestControllerTest.java
+++ b/src/test/java/gift/controller/WishRestControllerTest.java
@@ -95,7 +95,7 @@ class WishRestControllerTest {
         ResponseEntity<Void> response = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toBodilessEntity();
 
@@ -140,7 +140,7 @@ class WishRestControllerTest {
                 client.post()
                         .uri("http://localhost:" + port + "/api/wishes")
                         .header("Authorization", "Bearer " + token)
-                        .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), -10))
+                        .body(new CreateWishRequest(productResponse.getBody().id(), -10))
                         .retrieve()
                         .toBodilessEntity()
         ).isInstanceOf(HttpClientErrorException.BadRequest.class);
@@ -182,59 +182,15 @@ class WishRestControllerTest {
 
 
         //위시 리스트에 등록된 상품 조회
-        url = "http://localhost:" + port + "/api/wishes/{id}";
+        url = "http://localhost:" + port + "/api/wishes";
         ResponseEntity<Void> response = client.get()
-                .uri(url, registerResponse.getBody().id())
+                .uri(url)
                 .header("Authorization", "Bearer " + token)
                 .retrieve()
                 .toBodilessEntity();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-    }
-
-    @Test
-    @DisplayName("위시 리스트에 등록된 상품 조회 실패(조회하는 멤버가 없음)")
-    void 위시리스트에_등록된_상품_조회_실패() {
-        //상품 추가
-        String url = "http://localhost:" + port + "/api/products";
-        ResponseEntity<CreateProductResponse> productResponse = client.post()
-                .uri(url)
-                .body(new CreateProductRequest("product1", 1000, "exam.url"))
-                .retrieve()
-                .toEntity(CreateProductResponse.class);
-        assertThat(productResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-
-        url = "http://localhost:" + port + "/api/members/register";
-
-        // 회원가입 및 로그인
-        ResponseEntity<CreateMemberResponse> registerResponse = client.post()
-                .uri(url)
-                .body(new CreateMemberRequest("test@exam.com", "1234"))
-                .retrieve()
-                .toEntity(CreateMemberResponse.class);
-
-        url = "http://localhost:" + port + "/api/members/login";
-        ResponseEntity<LoginMemberResponse> loginResponse = client.post()
-                .uri(url)
-                .body(new LoginMemberRequest("test@exam.com", "1234"))
-                .retrieve()
-                .toEntity(LoginMemberResponse.class);
-
-        String body = loginResponse.getBody().toString();
-        int start = body.indexOf("token=") + "token=".length();
-        int end = body.indexOf("]", start);
-        String token = body.substring(start, end);
-
-
-        //위시 리스트에 등록된 상품 조회
-        assertThatThrownBy(() ->
-                client.get()
-                        .uri("http://localhost:" + port + "/api/wishes/{memberId}", registerResponse.getBody().id() - 500)
-                        .header("Authorization", "Bearer " + token)
-                        .retrieve()
-                        .toBodilessEntity()
-        ).isInstanceOf(HttpClientErrorException.NotFound.class);
     }
 
     @Test
@@ -274,7 +230,7 @@ class WishRestControllerTest {
         ResponseEntity<CreateWishResponse> addWishResponse = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toEntity(CreateWishResponse.class);
 
@@ -325,7 +281,7 @@ class WishRestControllerTest {
         ResponseEntity<CreateWishResponse> addWishResponse = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toEntity(CreateWishResponse.class);
 
@@ -382,7 +338,7 @@ class WishRestControllerTest {
         ResponseEntity<CreateWishResponse> addWishResponse = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toEntity(CreateWishResponse.class);
 
@@ -434,7 +390,7 @@ class WishRestControllerTest {
         ResponseEntity<CreateWishResponse> addWishResponse = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toEntity(CreateWishResponse.class);
 
@@ -485,7 +441,7 @@ class WishRestControllerTest {
         ResponseEntity<CreateWishResponse> addWishResponse = client.post()
                 .uri(url)
                 .header("Authorization", "Bearer " + token)
-                .body(new CreateWishRequest(registerResponse.getBody().id(), productResponse.getBody().id(), 1))
+                .body(new CreateWishRequest(productResponse.getBody().id(), 1))
                 .retrieve()
                 .toEntity(CreateWishResponse.class);
 


### PR DESCRIPTION
Step 3 위시리스트를 구현해보았습니다. 

1. Wish 도메인을 만들어서 이와 관려된 CRUD 로직을 작성해보았습니다. 
원래 MemberRestController에 있던 getProducts() 메서드를 WishRestController로 옮겼습니다. 해당 기능이 WishList를 사용자가 만드는데 필요한 로직이라고 생각했기 때문입니다. 

2. ArgumentResolver에 대한 부분이 강의 자료에 올라와 있었는데 이게 MVC에서 어떤 역할을 수행하는지에 대해서는 공부해보았습니다. 그런데 현재 제 코드 상에서 이 ArugmentResolver를 어느 부분에 적용할 수 있을지 잘 모르겠습니다. Login 에 대해서는 인터셉터를 통해서 토큰을 검사하는 로직을 작성해두었는데 제가 놓치고 있는 부분이 있을까요? 


- 고민했던 부분 
 현재 WishJdbcRepository 클래스가 Dto 패키지를 사용하고 있는데 이러면 Repository가 Dto를 의존하고 있어서 안티패턴이라고 봐야하는걸까요? (저는 필요로 의해 사용하는 것 자체가 의존성을 갖는다고 생각했습니다) Repository 영역에  파라미터로 `CreateWishRequest request` 이런 객체를 넘겨주기 보다 `ex) (Long id, String productName)` 이렇게 필드 값으로 넘겨주는게 더 객체 지향적인 설계인가요? 

  저번에 비즈니스 로직에 대해서 질문을 모호하게 드렸었는데 비즈니스 로직이 무엇인가에 대해 더 생각해보았습니다. 저는 비즈니스 로직이 구현하고 있는 도메인영역이라고 생각했습니다. 예를 들어 은행 도메인을 만든다고 하면 은행에서 돈을 입출력, 송금하는 로직이 비즈니스 로직인 것이죠. 지금 구현하고 있는 wishList에서는 위시 리스트에 상품을 추가하고 제거하는것 같은 것이 비즈니스 로직이 될 수 있다고 생각합니다. 구현하려고 하는 기능이 간단하기 때문에 Repository에 CURD 하는 작업과 크게 차이가 없어서 보이는 것이었습니다. 

  그리고 레이어드 아키텍쳐와 의존성에 대해서 나름대로 생각해았습니다. 레이어드 아키텍쳐는 의존성이 한 방향으로 흐르고, 상위 모듈은 하위 모듈에 대해서 알지 못합니다. 그리고 이 과정에서 interface를 활용해 의존관계 역전의 원칙이 지켜질 수 있고 하위 모듈을 보다 자유롭게 교체할 수 있게 되는 것 같습니다. 의존성이 맘대로 퍼져 있다면 의존성 전이에 의해서 코드를 수정할 범위가 더 커지고 유지 보수성이 떨어지는 것 같습니다. 그래서 interface를 활용해 상위 모듈과 하위 모듈을 나누는 것이 중요해보입니다. 그런데 또 interface를 무조건 만드는건 좋지 않은 것 같기도 합니다. 
https://techblog.woowahan.com/2561/ 해당 글에서는 serivce 레이어를 interface로 만드는 것이 언제나 좋은 것은 아니라고 말합니다. 그런데 레이어드 아키텍쳐의 본래 목적대로라면 service 레이어는 repository 레이어의 하위 모듈이고 interface를 만드는게 더 효과적일 것입니다. 이런 점에서 언제나 클린 코드나 객체지향적인 코드를 작성하는게 정답은 아닐 수도 있겠다는 생각이 들었습니다. 
