### PR TITLE
강원대 BE_김상수 3단계 - 위시 리스트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # spring-gift-product
 
+#### 위시리스트 기능 추가
+
+- 사용자별 위시리스트 상품 추가, 조회, 삭제(CRD) 기능 구현
+- 위시리스트 전체 기능에 대한 테스트 코드 작성
+- 커스텀 예외: `UnAuthenticatedException`, `ResourceNotFoundException` 추가
+- 토큰 만료, 토큰 유효성 오류, 리소스 미존재 시 대응하는 `ErrorCode` 추가
+
 #### 회원 인증(로그인/등록) 응답 코드 정책
 
 - 회원 등록 실패 시: **400 Bad Request**

--- a/src/main/java/gift/controller/member/MemberController.java
+++ b/src/main/java/gift/controller/member/MemberController.java
@@ -1,9 +1,9 @@
-package gift.controller;
+package gift.controller.member;
 
-import gift.dto.MemberPasswordChangeDto;
-import gift.dto.MemberRequestDto;
-import gift.dto.MemberResponseDto;
-import gift.service.MemberService;
+import gift.dto.member.MemberPasswordChangeDto;
+import gift.dto.member.MemberRequestDto;
+import gift.dto.member.MemberResponseDto;
+import gift.service.member.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/gift/controller/product/ProductController.java
+++ b/src/main/java/gift/controller/product/ProductController.java
@@ -1,8 +1,8 @@
-package gift.controller;
+package gift.controller.product;
 
-import gift.dto.ProductRequestDto;
-import gift.dto.ProductResponseDto;
-import gift.service.ProductService;
+import gift.dto.product.ProductRequestDto;
+import gift.dto.product.ProductResponseDto;
+import gift.service.product.ProductService;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/gift/controller/product/ProductViewController.java
+++ b/src/main/java/gift/controller/product/ProductViewController.java
@@ -1,8 +1,8 @@
-package gift.controller;
+package gift.controller.product;
 
-import gift.dto.ProductRequestDto;
-import gift.dto.ProductResponseDto;
-import gift.service.ProductService;
+import gift.dto.product.ProductRequestDto;
+import gift.dto.product.ProductResponseDto;
+import gift.service.product.ProductService;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/gift/controller/wishlist/WishListController.java
+++ b/src/main/java/gift/controller/wishlist/WishListController.java
@@ -1,11 +1,14 @@
 package gift.controller.wishlist;
 
+import gift.dto.product.ProductResponseDto;
 import gift.dto.wishlist.WishRequestDto;
 import gift.entity.LoginMember;
 import gift.entity.Member;
 import gift.service.wishlist.WishListService;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +31,12 @@ public class WishListController {
         wishListService.create(requestDto);
 
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductResponseDto>> findAll(
+        @LoginMember Member member
+    ) {
+        return new ResponseEntity<>(wishListService.findAll(member.getId()), HttpStatus.OK);
     }
 }

--- a/src/main/java/gift/controller/wishlist/WishListController.java
+++ b/src/main/java/gift/controller/wishlist/WishListController.java
@@ -39,4 +39,14 @@ public class WishListController {
     ) {
         return new ResponseEntity<>(wishListService.findAll(member.getId()), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> delete(
+        @PathVariable Long productId,
+        @LoginMember Member member
+    ) {
+        wishListService.delete(productId, member.getId());
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/gift/controller/wishlist/WishListController.java
+++ b/src/main/java/gift/controller/wishlist/WishListController.java
@@ -1,0 +1,32 @@
+package gift.controller.wishlist;
+
+import gift.dto.wishlist.WishRequestDto;
+import gift.entity.LoginMember;
+import gift.entity.Member;
+import gift.service.wishlist.WishListService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/wishes")
+public class WishListController {
+    private final WishListService wishListService;
+
+    public WishListController(WishListService wishListService) {
+        this.wishListService = wishListService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> create(
+        @RequestBody WishRequestDto requestDto,
+        @LoginMember Member member
+    ) {
+        wishListService.create(requestDto);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/gift/controller/wishlist/WishListController.java
+++ b/src/main/java/gift/controller/wishlist/WishListController.java
@@ -28,7 +28,7 @@ public class WishListController {
         @RequestBody WishRequestDto requestDto,
         @LoginMember Member member
     ) {
-        wishListService.create(requestDto);
+        wishListService.create(requestDto, member.getId());
 
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/gift/controller/wishlist/WishListController.java
+++ b/src/main/java/gift/controller/wishlist/WishListController.java
@@ -1,16 +1,16 @@
 package gift.controller.wishlist;
 
 import gift.dto.product.ProductResponseDto;
-import gift.dto.wishlist.WishRequestDto;
 import gift.entity.LoginMember;
 import gift.entity.Member;
 import gift.service.wishlist.WishListService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,12 +23,12 @@ public class WishListController {
         this.wishListService = wishListService;
     }
 
-    @PostMapping
+    @PostMapping("/{productId}")
     public ResponseEntity<Void> create(
-        @RequestBody WishRequestDto requestDto,
+        @PathVariable Long productId,
         @LoginMember Member member
     ) {
-        wishListService.create(requestDto, member.getId());
+        wishListService.create(productId, member.getId());
 
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/gift/dto/member/MemberPasswordChangeDto.java
+++ b/src/main/java/gift/dto/member/MemberPasswordChangeDto.java
@@ -1,4 +1,4 @@
-package gift.dto;
+package gift.dto.member;
 
 public record MemberPasswordChangeDto(String email, String beforePassword, String afterPassword) {
 

--- a/src/main/java/gift/dto/member/MemberRequestDto.java
+++ b/src/main/java/gift/dto/member/MemberRequestDto.java
@@ -1,4 +1,4 @@
-package gift.dto;
+package gift.dto.member;
 
 public record MemberRequestDto(String email, String password) {
 }

--- a/src/main/java/gift/dto/member/MemberResponseDto.java
+++ b/src/main/java/gift/dto/member/MemberResponseDto.java
@@ -1,4 +1,4 @@
-package gift.dto;
+package gift.dto.member;
 
 public record MemberResponseDto (String token) {
 }

--- a/src/main/java/gift/dto/member/MemberResponseDto2.java
+++ b/src/main/java/gift/dto/member/MemberResponseDto2.java
@@ -1,0 +1,5 @@
+package gift.dto.member;
+
+public record MemberResponseDto2(Long id, String email, String password) {
+
+}

--- a/src/main/java/gift/dto/product/ProductRequestDto.java
+++ b/src/main/java/gift/dto/product/ProductRequestDto.java
@@ -1,4 +1,4 @@
-package gift.dto;
+package gift.dto.product;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/gift/dto/product/ProductResponseDto.java
+++ b/src/main/java/gift/dto/product/ProductResponseDto.java
@@ -1,4 +1,4 @@
-package gift.dto;
+package gift.dto.product;
 
 import gift.entity.Product;
 

--- a/src/main/java/gift/dto/wishlist/WishRequestDto.java
+++ b/src/main/java/gift/dto/wishlist/WishRequestDto.java
@@ -1,0 +1,5 @@
+package gift.dto.wishlist;
+
+public record WishRequestDto(Long productId, Long memberId) {
+
+}

--- a/src/main/java/gift/dto/wishlist/WishRequestDto.java
+++ b/src/main/java/gift/dto/wishlist/WishRequestDto.java
@@ -1,5 +1,5 @@
 package gift.dto.wishlist;
 
-public record WishRequestDto(Long productId, Long memberId) {
+public record WishRequestDto(Long productId) {
 
 }

--- a/src/main/java/gift/dto/wishlist/WishRequestDto.java
+++ b/src/main/java/gift/dto/wishlist/WishRequestDto.java
@@ -1,5 +1,0 @@
-package gift.dto.wishlist;
-
-public record WishRequestDto(Long productId) {
-
-}

--- a/src/main/java/gift/entity/LoginMember.java
+++ b/src/main/java/gift/entity/LoginMember.java
@@ -1,0 +1,11 @@
+package gift.entity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface LoginMember {
+}

--- a/src/main/java/gift/entity/Member.java
+++ b/src/main/java/gift/entity/Member.java
@@ -5,6 +5,8 @@ public class Member {
     String email;
     String password;
 
+    public Member() {}
+
     public Member(String email, String password) {
         this.email = email;
         this.password = password;
@@ -15,6 +17,8 @@ public class Member {
         this.email = email;
         this.password = password;
     }
+
+    public Long getId() { return this.id; }
 
     public String getEmail() {
         return this.email;

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -1,12 +1,23 @@
 package gift.entity;
 
 public class Wish {
+    Long id;
     Long productId;
     Long memberId;
 
     public Wish(Long productId, Long memberId) {
         this.productId = productId;
         this.memberId = memberId;
+    }
+
+    public Wish(Long id, Long productId, Long memberId) {
+        this.id = id;
+        this.productId = productId;
+        this.memberId = memberId;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public Long getProductId() {

--- a/src/main/java/gift/entity/Wish.java
+++ b/src/main/java/gift/entity/Wish.java
@@ -1,0 +1,19 @@
+package gift.entity;
+
+public class Wish {
+    Long productId;
+    Long memberId;
+
+    public Wish(Long productId, Long memberId) {
+        this.productId = productId;
+        this.memberId = memberId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/src/main/java/gift/exception/ErrorCode.java
+++ b/src/main/java/gift/exception/ErrorCode.java
@@ -50,6 +50,12 @@ public enum ErrorCode {
         HttpStatus.INTERNAL_SERVER_ERROR,
         "D003",
         "데이터베이스 처리 중 오류가 발생했습니다."
+    ),
+
+    RESOURCE_NOT_FOUND(
+        HttpStatus.NOT_FOUND,
+        "C001",
+        "요청한 리소스를 찾을 수 없습니다."
     );
 
     private HttpStatus status;

--- a/src/main/java/gift/exception/ErrorCode.java
+++ b/src/main/java/gift/exception/ErrorCode.java
@@ -3,8 +3,54 @@ package gift.exception;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "P001", "상품 입력값이 유효하지 않습니다."),
-    NO_SUPPORTED_SHA256_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "E001", "SHA-256 알고리즘을 지원하지 않습니다.");
+    INVALID_INPUT_VALUE(
+        HttpStatus.BAD_REQUEST,
+        "P001",
+        "상품 입력값이 유효하지 않습니다."
+    ),
+
+    NO_SUPPORTED_SHA256_ALGORITHM(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "E001",
+
+        "SHA-256 알고리즘을 지원하지 않습니다."
+    ),
+
+    UNAUTHENICATED_LOGIN(
+        HttpStatus.UNAUTHORIZED,
+        "E002",
+        "로그인이 필요합니다. 인증되지 않은 사용자입니다."
+    ),
+
+    EXPIRED_TOKEN_ERROR(
+        HttpStatus.BAD_REQUEST,
+        "T001",
+        "인증 토큰이 만료되었습니다. 다시 로그인해주세요."
+    ),
+
+    INVALID_TOKEN_SIGNATURE(
+        HttpStatus.UNAUTHORIZED,
+        "T002",
+        "유효하지 않은 토큰입니다. 토큰이 변조되었거나 위조되었습니다."
+    ),
+
+    DUPLICATE_RESOURCE(
+        HttpStatus.CONFLICT,
+        "D001",
+        "이미 등록된 리소스입니다."
+    ),
+
+    DATA_INTEGRITY_ERROR(
+        HttpStatus.BAD_REQUEST,
+        "D002",
+        "연관된 리소스를 찾을 수 없습니다. 존재하지 않는 회원 또는 상품입니다."
+    ),
+
+    DATABASE_ERROR(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "D003",
+        "데이터베이스 처리 중 오류가 발생했습니다."
+    );
 
     private HttpStatus status;
     private String errorCode;

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -86,4 +86,12 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TOKEN_SIGNATURE);
         return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
     }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
+        ResourceNotFoundException exception
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND);
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
 }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -1,7 +1,12 @@
 package gift.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.sql.SQLException;
 import java.util.List;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -34,5 +39,51 @@ public class GlobalExceptionHandler {
     ) {
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NO_SUPPORTED_SHA256_ALGORITHM);
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(UnAuthenicatedException.class)
+    public ResponseEntity<ErrorResponse> handleUnAuthenicatedException(
+        UnAuthenicatedException exception
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHENICATED_LOGIN);
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+        DataIntegrityViolationException exception
+    ) {
+        Throwable rootCause = exception.getMostSpecificCause();
+
+        if (rootCause instanceof SQLException sqlException) {
+            String sqlState = sqlException.getSQLState();
+
+            if ("23505".equals(sqlState)) {
+                ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.DUPLICATE_RESOURCE);
+                return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+            } else if ("23506".equals(sqlState)) {
+                ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.DATA_INTEGRITY_ERROR);
+                return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.DATABASE_ERROR);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ErrorResponse> handleExpiredJwtException(
+        ExpiredJwtException exception
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.EXPIRED_TOKEN_ERROR);
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ErrorResponse> handleSignatureException(
+        JwtException exception
+    ) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TOKEN_SIGNATURE);
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/gift/exception/ResourceNotFoundException.java
+++ b/src/main/java/gift/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package gift.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException() {
+
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/exception/UnAuthenicatedException.java
+++ b/src/main/java/gift/exception/UnAuthenicatedException.java
@@ -1,0 +1,11 @@
+package gift.exception;
+
+public class UnAuthenicatedException extends RuntimeException {
+    public UnAuthenicatedException() {
+
+    }
+
+    public UnAuthenicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gift/repository/member/MemberRepository.java
+++ b/src/main/java/gift/repository/member/MemberRepository.java
@@ -1,4 +1,4 @@
-package gift.repository;
+package gift.repository.member;
 
 import gift.entity.Member;
 import java.util.Optional;
@@ -14,4 +14,6 @@ public interface MemberRepository {
     public boolean existsByEmail(String email);
 
     void resetPassword(Member member);
+
+    public Optional<Member> findById(Long id);
 }

--- a/src/main/java/gift/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/gift/repository/member/MemberRepositoryImpl.java
@@ -1,6 +1,5 @@
-package gift.repository;
+package gift.repository.member;
 
-import gift.dto.MemberRequestDto;
 import gift.entity.Member;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,5 +78,15 @@ public class MemberRepositoryImpl implements MemberRepository {
             .param("password", member.getPassword())
             .param("email", member.getEmail())
             .update();
+    }
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        String sql = "select * from member where id = :id";
+
+        return jdbcClient.sql(sql)
+            .param("id", id)
+            .query(MEMBER_ROW_MAPPER)
+            .optional();
     }
 }

--- a/src/main/java/gift/repository/product/ProductRepository.java
+++ b/src/main/java/gift/repository/product/ProductRepository.java
@@ -1,7 +1,7 @@
-package gift.repository;
+package gift.repository.product;
 
 
-import gift.dto.ProductRequestDto;
+import gift.dto.product.ProductRequestDto;
 import gift.entity.Product;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/gift/repository/product/ProductRepositoryImpl.java
+++ b/src/main/java/gift/repository/product/ProductRepositoryImpl.java
@@ -1,6 +1,6 @@
-package gift.repository;
+package gift.repository.product;
 
-import gift.dto.ProductRequestDto;
+import gift.dto.product.ProductRequestDto;
 import gift.entity.Product;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/gift/repository/wishlist/WishListRepository.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepository.java
@@ -7,4 +7,6 @@ public interface WishListRepository {
     public Wish create(Wish wish);
 
     List<Wish> findAll(Long memberId);
+
+    int delete(Long productId, Long memberId);
 }

--- a/src/main/java/gift/repository/wishlist/WishListRepository.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepository.java
@@ -2,7 +2,10 @@ package gift.repository.wishlist;
 
 import gift.dto.wishlist.WishRequestDto;
 import gift.entity.Wish;
+import java.util.List;
 
 public interface WishListRepository {
     public Wish create(Wish wish);
+
+    List<Wish> findAll(Long memberId);
 }

--- a/src/main/java/gift/repository/wishlist/WishListRepository.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepository.java
@@ -1,0 +1,8 @@
+package gift.repository.wishlist;
+
+import gift.dto.wishlist.WishRequestDto;
+import gift.entity.Wish;
+
+public interface WishListRepository {
+    public Wish create(Wish wish);
+}

--- a/src/main/java/gift/repository/wishlist/WishListRepository.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepository.java
@@ -1,6 +1,5 @@
 package gift.repository.wishlist;
 
-import gift.dto.wishlist.WishRequestDto;
 import gift.entity.Wish;
 import java.util.List;
 

--- a/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
@@ -1,0 +1,28 @@
+package gift.repository.wishlist;
+
+import gift.entity.Wish;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class WishListRepositoryImpl implements WishListRepository {
+
+    private final JdbcClient jdbcClient;
+
+    public WishListRepositoryImpl(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+
+    @Override
+    public Wish create(Wish wish) {
+        String sql = "insert into wishlist(product_id, member_id) values (:productId, :memberId)";
+
+        jdbcClient.sql(sql)
+            .param("productId", wish.getProductId())
+            .param("memberId", wish.getMemberId())
+            .update();
+
+        return wish;
+    }
+}

--- a/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
@@ -2,12 +2,9 @@ package gift.repository.wishlist;
 
 import gift.entity.Wish;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
-import org.springframework.web.server.ResponseStatusException;
 
 @Repository
 public class WishListRepositoryImpl implements WishListRepository {

--- a/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
@@ -1,6 +1,8 @@
 package gift.repository.wishlist;
 
 import gift.entity.Wish;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +10,8 @@ import org.springframework.stereotype.Repository;
 public class WishListRepositoryImpl implements WishListRepository {
 
     private final JdbcClient jdbcClient;
+    private static final RowMapper<Wish> WISH_ROW_MAPPER = ((rs, rowNum) -> new Wish(
+        rs.getLong("id"), rs.getLong("product_id"), rs.getLong("member_id")));
 
     public WishListRepositoryImpl(JdbcClient jdbcClient) {
         this.jdbcClient = jdbcClient;
@@ -24,5 +28,17 @@ public class WishListRepositoryImpl implements WishListRepository {
             .update();
 
         return wish;
+    }
+
+    @Override
+    public List<Wish> findAll(Long memberId) {
+        String sql = "select id, product_id, member_id from wishlist where member_id = :memberId";
+
+        List<Wish> wishList = jdbcClient.sql(sql)
+            .param("memberId", memberId)
+            .query(WISH_ROW_MAPPER)
+            .list();
+
+        return wishList;
     }
 }

--- a/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
+++ b/src/main/java/gift/repository/wishlist/WishListRepositoryImpl.java
@@ -2,9 +2,12 @@ package gift.repository.wishlist;
 
 import gift.entity.Wish;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
 
 @Repository
 public class WishListRepositoryImpl implements WishListRepository {
@@ -40,5 +43,17 @@ public class WishListRepositoryImpl implements WishListRepository {
             .list();
 
         return wishList;
+    }
+
+    @Override
+    public int delete(Long productId, Long memberId) {
+        String sql = "delete from wishlist where product_id = :productId and member_id = :memberId";
+
+        int deleteRow = jdbcClient.sql(sql)
+            .param("productId", productId)
+            .param("memberId", memberId)
+            .update();
+
+        return deleteRow;
     }
 }

--- a/src/main/java/gift/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/gift/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,51 @@
+package gift.resolver;
+
+import gift.dto.member.MemberResponseDto2;
+import gift.entity.LoginMember;
+import gift.entity.Member;
+import gift.exception.UnAuthenicatedException;
+import gift.service.member.MemberService;
+import gift.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+    private final JwtUtil jwtUtil;
+
+    public LoginMemberArgumentResolver(MemberService memberService, JwtUtil jwtUtil) {
+        this.memberService = memberService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request
+            = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String authenicatedHeader = request.getHeader("Authorization");
+
+        if (authenicatedHeader == null || !authenicatedHeader.startsWith("Bearer ")) {
+            throw new UnAuthenicatedException("요청 헤더에 Authorization이 없습니다.");
+        }
+
+        String token = authenicatedHeader.substring(7);
+        Long memberId = jwtUtil.getMemberIdFromToken(token);
+        MemberResponseDto2 responseDto = memberService.findById(memberId);
+
+        return new Member(responseDto.id(), responseDto.email(), responseDto.password());
+    }
+}

--- a/src/main/java/gift/resolver/WebConfig.java
+++ b/src/main/java/gift/resolver/WebConfig.java
@@ -1,0 +1,18 @@
+package gift.resolver;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/gift/service/member/MemberService.java
+++ b/src/main/java/gift/service/member/MemberService.java
@@ -1,8 +1,9 @@
-package gift.service;
+package gift.service.member;
 
-import gift.dto.MemberPasswordChangeDto;
-import gift.dto.MemberRequestDto;
-import gift.dto.MemberResponseDto;
+import gift.dto.member.MemberPasswordChangeDto;
+import gift.dto.member.MemberRequestDto;
+import gift.dto.member.MemberResponseDto;
+import gift.dto.member.MemberResponseDto2;
 
 public interface MemberService {
 
@@ -13,4 +14,6 @@ public interface MemberService {
     void changePassword(MemberPasswordChangeDto requestDto);
 
     void resetPassword(MemberRequestDto requestDto);
+
+    MemberResponseDto2 findById(Long id);
 }

--- a/src/main/java/gift/service/member/MemberServiceImpl.java
+++ b/src/main/java/gift/service/member/MemberServiceImpl.java
@@ -1,10 +1,11 @@
-package gift.service;
+package gift.service.member;
 
-import gift.dto.MemberPasswordChangeDto;
-import gift.dto.MemberRequestDto;
-import gift.dto.MemberResponseDto;
+import gift.dto.member.MemberPasswordChangeDto;
+import gift.dto.member.MemberRequestDto;
+import gift.dto.member.MemberResponseDto;
+import gift.dto.member.MemberResponseDto2;
 import gift.entity.Member;
-import gift.repository.MemberRepository;
+import gift.repository.member.MemberRepository;
 import gift.util.JwtUtil;
 import gift.util.Sha256Util;
 import org.springframework.http.HttpStatus;
@@ -34,13 +35,14 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.create(
             new Member(requestDto.email(), sha256Util.encrypt(requestDto.password())));
 
-        String accessToken = jwtUtil.createToken(member.getEmail());
+        String accessToken = jwtUtil.createToken(member.getId(), member.getEmail());
 
         return new MemberResponseDto(accessToken);
     }
 
     @Override
     public MemberResponseDto login(MemberRequestDto requestDto) {
+        // TODO: 이후에 '이메일:생성 가능 아이디'가 1:N인지, 1:1인지 따로 조건이 없으므로 변경 필요할 수 있음. (현재는 1:1이라고 가정)
         Member member = memberRepository.findByEmail(requestDto.email())
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN));
 
@@ -48,7 +50,7 @@ public class MemberServiceImpl implements MemberService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);
         }
 
-        String accessToken = jwtUtil.createToken(requestDto.email());
+        String accessToken = jwtUtil.createToken(member.getId(), member.getEmail());
 
         return new MemberResponseDto(accessToken);
     }
@@ -76,5 +78,13 @@ public class MemberServiceImpl implements MemberService {
 
         memberRepository.resetPassword(
             new Member(requestDto.email(), sha256Util.encrypt(requestDto.password())));
+    }
+
+    @Override
+    public MemberResponseDto2 findById(Long id) {
+        Member member = memberRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN));
+
+        return new MemberResponseDto2(member.getId(), member.getEmail(), member.getPassword());
     }
 }

--- a/src/main/java/gift/service/product/ProductService.java
+++ b/src/main/java/gift/service/product/ProductService.java
@@ -1,11 +1,8 @@
-package gift.service;
+package gift.service.product;
 
-import gift.dto.ProductRequestDto;
-import gift.dto.ProductResponseDto;
-import gift.entity.Product;
-import java.util.HashMap;
+import gift.dto.product.ProductRequestDto;
+import gift.dto.product.ProductResponseDto;
 import java.util.List;
-import java.util.Map;
 
 public interface ProductService {
 

--- a/src/main/java/gift/service/product/ProductServiceImpl.java
+++ b/src/main/java/gift/service/product/ProductServiceImpl.java
@@ -1,9 +1,9 @@
-package gift.service;
+package gift.service.product;
 
-import gift.dto.ProductRequestDto;
-import gift.dto.ProductResponseDto;
+import gift.dto.product.ProductRequestDto;
+import gift.dto.product.ProductResponseDto;
 import gift.entity.Product;
-import gift.repository.ProductRepository;
+import gift.repository.product.ProductRepository;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/gift/service/wishlist/WishListService.java
+++ b/src/main/java/gift/service/wishlist/WishListService.java
@@ -1,11 +1,10 @@
 package gift.service.wishlist;
 
 import gift.dto.product.ProductResponseDto;
-import gift.dto.wishlist.WishRequestDto;
 import java.util.List;
 
 public interface WishListService {
-    public void create(WishRequestDto requestDto, Long memberId);
+    public void create(Long productId, Long memberId);
 
     List<ProductResponseDto> findAll(Long memberId);
 }

--- a/src/main/java/gift/service/wishlist/WishListService.java
+++ b/src/main/java/gift/service/wishlist/WishListService.java
@@ -1,0 +1,7 @@
+package gift.service.wishlist;
+
+import gift.dto.wishlist.WishRequestDto;
+
+public interface WishListService {
+    public void create(WishRequestDto requestDto);
+}

--- a/src/main/java/gift/service/wishlist/WishListService.java
+++ b/src/main/java/gift/service/wishlist/WishListService.java
@@ -7,4 +7,6 @@ public interface WishListService {
     public void create(Long productId, Long memberId);
 
     List<ProductResponseDto> findAll(Long memberId);
+
+    void delete(Long productId, Long memberId);
 }

--- a/src/main/java/gift/service/wishlist/WishListService.java
+++ b/src/main/java/gift/service/wishlist/WishListService.java
@@ -1,7 +1,11 @@
 package gift.service.wishlist;
 
+import gift.dto.product.ProductResponseDto;
 import gift.dto.wishlist.WishRequestDto;
+import java.util.List;
 
 public interface WishListService {
     public void create(WishRequestDto requestDto);
+
+    List<ProductResponseDto> findAll(Long memberId);
 }

--- a/src/main/java/gift/service/wishlist/WishListService.java
+++ b/src/main/java/gift/service/wishlist/WishListService.java
@@ -5,7 +5,7 @@ import gift.dto.wishlist.WishRequestDto;
 import java.util.List;
 
 public interface WishListService {
-    public void create(WishRequestDto requestDto);
+    public void create(WishRequestDto requestDto, Long memberId);
 
     List<ProductResponseDto> findAll(Long memberId);
 }

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -1,16 +1,13 @@
 package gift.service.wishlist;
 
 import gift.dto.product.ProductResponseDto;
-import gift.dto.wishlist.WishRequestDto;
 import gift.entity.Product;
 import gift.entity.Wish;
-import gift.exception.UnAuthenicatedException;
 import gift.repository.product.ProductRepository;
 import gift.repository.wishlist.WishListRepository;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -28,9 +25,9 @@ public class WishListServiceImpl implements WishListService {
     }
 
     @Override
-    public void create(WishRequestDto requestDto, Long memberId) {
+    public void create(Long productId, Long memberId) {
         Wish wish = wishListRepository.create(
-            new Wish(requestDto.productId(), memberId));
+            new Wish(productId, memberId));
     }
 
     @Override

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -3,16 +3,13 @@ package gift.service.wishlist;
 import gift.dto.product.ProductResponseDto;
 import gift.entity.Product;
 import gift.entity.Wish;
+import gift.exception.ResourceNotFoundException;
 import gift.repository.product.ProductRepository;
 import gift.repository.wishlist.WishListRepository;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException.NotFound;
-import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class WishListServiceImpl implements WishListService {
@@ -39,7 +36,7 @@ public class WishListServiceImpl implements WishListService {
 
         for (Wish wish : wishList) {
             Product product = productRepository.findById(wish.getProductId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new ResourceNotFoundException());
 
             responseDtoList.add(
                 new ProductResponseDto(product.getId(), product.getName(), product.getPrice(),
@@ -56,7 +53,7 @@ public class WishListServiceImpl implements WishListService {
         int deleteRow = wishListRepository.delete(productId, memberId);
 
         if (deleteRow <= 0) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+            throw new ResourceNotFoundException();
         }
     }
 }

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -1,22 +1,52 @@
 package gift.service.wishlist;
 
+import gift.dto.product.ProductResponseDto;
 import gift.dto.wishlist.WishRequestDto;
+import gift.entity.Product;
 import gift.entity.Wish;
+import gift.repository.product.ProductRepository;
 import gift.repository.wishlist.WishListRepository;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class WishListServiceImpl implements WishListService {
 
     private final WishListRepository wishListRepository;
+    private final ProductRepository productRepository;
 
-    public WishListServiceImpl(WishListRepository wishListRepository) {
+    public WishListServiceImpl(WishListRepository wishListRepository,
+        ProductRepository productRepository) {
         this.wishListRepository = wishListRepository;
+        this.productRepository = productRepository;
     }
 
     @Override
     public void create(WishRequestDto requestDto) {
         Wish wish = wishListRepository.create(
             new Wish(requestDto.productId(), requestDto.memberId()));
+    }
+
+    @Override
+    public List<ProductResponseDto> findAll(Long memberId) {
+        List<Wish> wishList = wishListRepository.findAll(memberId);
+        List<ProductResponseDto> responseDtoList = new ArrayList<>();
+
+        for (Wish wish : wishList) {
+            Product product = productRepository.findById(wish.getProductId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+            responseDtoList.add(
+                new ProductResponseDto(product.getId(), product.getName(), product.getPrice(),
+                    product.getImageUrl()));
+        }
+
+        return responseDtoList.stream()
+            .sorted(Comparator.comparing(ProductResponseDto::id))
+            .toList();
     }
 }

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -8,8 +8,10 @@ import gift.repository.wishlist.WishListRepository;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
@@ -47,5 +49,14 @@ public class WishListServiceImpl implements WishListService {
         return responseDtoList.stream()
             .sorted(Comparator.comparing(ProductResponseDto::id))
             .toList();
+    }
+
+    @Override
+    public void delete(Long productId, Long memberId) {
+        int deleteRow = wishListRepository.delete(productId, memberId);
+
+        if (deleteRow <= 0) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -4,11 +4,13 @@ import gift.dto.product.ProductResponseDto;
 import gift.dto.wishlist.WishRequestDto;
 import gift.entity.Product;
 import gift.entity.Wish;
+import gift.exception.UnAuthenicatedException;
 import gift.repository.product.ProductRepository;
 import gift.repository.wishlist.WishListRepository;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -26,9 +28,9 @@ public class WishListServiceImpl implements WishListService {
     }
 
     @Override
-    public void create(WishRequestDto requestDto) {
+    public void create(WishRequestDto requestDto, Long memberId) {
         Wish wish = wishListRepository.create(
-            new Wish(requestDto.productId(), requestDto.memberId()));
+            new Wish(requestDto.productId(), memberId));
     }
 
     @Override

--- a/src/main/java/gift/service/wishlist/WishListServiceImpl.java
+++ b/src/main/java/gift/service/wishlist/WishListServiceImpl.java
@@ -1,0 +1,22 @@
+package gift.service.wishlist;
+
+import gift.dto.wishlist.WishRequestDto;
+import gift.entity.Wish;
+import gift.repository.wishlist.WishListRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WishListServiceImpl implements WishListService {
+
+    private final WishListRepository wishListRepository;
+
+    public WishListServiceImpl(WishListRepository wishListRepository) {
+        this.wishListRepository = wishListRepository;
+    }
+
+    @Override
+    public void create(WishRequestDto requestDto) {
+        Wish wish = wishListRepository.create(
+            new Wish(requestDto.productId(), requestDto.memberId()));
+    }
+}

--- a/src/main/java/gift/util/JwtUtil.java
+++ b/src/main/java/gift/util/JwtUtil.java
@@ -1,7 +1,6 @@
 package gift.util;
 
-import com.fasterxml.jackson.databind.ser.Serializers.Base;
-import gift.entity.Member;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -32,16 +31,27 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(String email) {
+    public String createToken(Long id, String email) {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + tokenTime);
 
         return Jwts.builder()
             .setSubject(email)
+            .claim("id", id)
             .claim("email", email)
             .setIssuedAt(now)
             .setExpiration(expiredDate)
             .signWith(key)
             .compact();
+    }
+
+    public Long getMemberIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        return claims.get("id", Long.class);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,4 +6,4 @@ insert into product(name, price, imageUrl)
 values ('Grapefruit Honey Black Tea', 5900, 'https://www.starbucks.co.kr/index.do');
 
 insert into member(email, password)
-values ('example@naver.com', 'qwer');
+values ('example@naver.com', 'f6f2ea8f45d8a057c9566a33f99474da2e5c6a6604d736121650e2730c6fb0a3');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -9,4 +9,13 @@ create table member (
   id bigint auto_increment primary key,
   email varchar(255),
   password varchar(255)
-)
+);
+
+create table wishlist (
+  id bigint auto_increment primary key,
+  product_id bigint,
+  member_id bigint,
+  foreign key(product_id) references product(id) on delete cascade,
+  foreign key(member_id) references member(id) on delete cascade,
+  unique (product_id, member_id)
+);

--- a/src/test/java/gift/MemberControllerTest.java
+++ b/src/test/java/gift/MemberControllerTest.java
@@ -3,9 +3,8 @@ package gift;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import gift.dto.MemberPasswordChangeDto;
-import gift.dto.MemberRequestDto;
-import org.junit.jupiter.api.Assertions;
+import gift.dto.member.MemberPasswordChangeDto;
+import gift.dto.member.MemberRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/gift/ProductControllerTest.java
+++ b/src/test/java/gift/ProductControllerTest.java
@@ -3,8 +3,8 @@ package gift;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import gift.dto.ProductRequestDto;
-import gift.dto.ProductResponseDto;
+import gift.dto.product.ProductRequestDto;
+import gift.dto.product.ProductResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/gift/WishListControllerTest.java
+++ b/src/test/java/gift/WishListControllerTest.java
@@ -1,0 +1,150 @@
+package gift;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gift.controller.wishlist.WishListController;
+import gift.dto.member.MemberResponseDto2;
+import gift.exception.UnAuthenicatedException;
+import gift.resolver.LoginMemberArgumentResolver;
+import gift.service.member.MemberService;
+import gift.service.wishlist.WishListService;
+import gift.util.JwtUtil;
+import gift.util.Sha256Util;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = WishListController.class)
+@Import({LoginMemberArgumentResolver.class})
+public class WishListControllerTest {
+
+    @Autowired
+    private MockMvc mockmvc;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private Sha256Util sha256Util;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @MockitoBean
+    private WishListService wishListService;
+
+    @Test
+    @DisplayName("위시리스트 생성 - 성공")
+    void createWishTest_success() throws Exception {
+        String token = "fake-jwt-token";
+        Long memberId = 1L;
+        String email = "example@naver.com";
+        String encryptedPassword = sha256Util.encrypt("qwer");
+
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willReturn(memberId);
+        given(memberService.findById(memberId))
+            .willReturn(new MemberResponseDto2(memberId, email, encryptedPassword));
+
+        mockmvc.perform(post("/api/wishes/1")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("위시리스트 생성 - 실패")
+    void createWishTest_fail() throws Exception {
+        String token = "fake-jwt-token";
+
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willThrow(new UnAuthenicatedException());
+
+        mockmvc.perform(post("/api/wishes/1")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("위시리스트 조회 - 성공")
+    void findAllWishTest_success() throws Exception {
+        String token = "fake-jwt-token";
+        Long memberId = 1L;
+        String email = "example@naver.com";
+        String encryptedPassword = sha256Util.encrypt("qwer");
+
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willReturn(memberId);
+        given(memberService.findById(memberId))
+            .willReturn(new MemberResponseDto2(memberId, email, encryptedPassword));
+
+        mockmvc.perform(get("/api/wishes")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("위시리스트 조회 - 실패")
+    void findAllWishTest_fail() throws Exception {
+        String token = "fake-jwt-token";
+        Long memberId = 1L;
+        String email = "example@naver.com";
+        String encryptedPassword = sha256Util.encrypt("qwer");
+
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willThrow(new UnAuthenicatedException());
+
+        mockmvc.perform(get("/api/wishes")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("위시리스트 삭제 - 성공")
+    void deleteWishTest_success() throws Exception {
+        String token = "fake-jwt-token";
+        Long memberId = 1L;
+        String email = "example@naver.com";
+        String encryptedPassword = sha256Util.encrypt("qwer");
+        
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willReturn(memberId);
+        given(memberService.findById(memberId))
+            .willReturn(new MemberResponseDto2(memberId, email, encryptedPassword));
+        
+        mockmvc.perform(delete("/api/wishes/1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("위시리스트 삭제 - 실패")
+    void deleteWishTest_fail() throws Exception {
+        String token = "fake-jwt-token";
+        Long memberId = 1L;
+        String email = "example@naver.com";
+        String encryptedPassword = sha256Util.encrypt("qwer");
+
+        given(jwtUtil.getMemberIdFromToken(token))
+            .willThrow(new UnAuthenicatedException());
+
+        mockmvc.perform(delete("/api/wishes/1")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 📌주요 변경 내역

- 사용자별 위시리스트 상품 추가, 조회, 삭제 기능 구현 (CRD)

- 상품 추가 API 리팩토링: memberId를 DTO에서 제거하고 인증 토큰 기반으로 사용자 식별

- API URI 구조 개선: RESTful 원칙에 따라 자원을 명확히 표현하도록 변경
**(Question 2)**

- 예외 처리 개선: 존재하지 않는 리소스 요청 시 **ResourceNotFoundException**을 반환하도록 통일

- 전체 위시리스트 기능에 대한 테스트 코드 추가
**(Question 1)**


## ❗ 주의사항
application.properties의 jwt.secret에 해당 secretKey값을 채워주셔야 합니다!!! (env 처리)
https://edu.nextstep.camp/s/UH6H8Iba/ls/hWjSNfg0


## 궁금한 점
### Q1. mock 테스트 코드는 어느 정도로 구현해야 하는지 궁금합니다.

### Q2. 이번 백엔드 강의에서는 `/api/wishes` 요청의 본문(body)에 productId를 담아 위시리스트 아이템을 생성하고 있는 것 같습니다 !
혹시 POST /api/wishes/{productId}와 같이 productId를 URI에 포함하여 자원을 명시하는 방식에 대해서는 어떻게 생각하시는지 궁금합니다.
ex) `확장성` 측면 등