### PR TITLE
부산대 BE_신세환 step3 - 위시 리스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@
 - [x] 위시 리스트 service, controller 설계
 - [x] 위시 리스트 페이지 구현
 - [x] 상품 관리 관리자 페이지 접근 권한 검증
-- [ ] 회원 수정, 삭제에 필요한 service, repository 추가 구현
-- [ ] 회원 수정, 삭제 페이지 구현
+- [x] 회원 수정, 삭제에 필요한 service, repository 추가 구현
+- [x] 회원 수정, 삭제 페이지 구현
 - [ ] 암호화 적용하기
 
 # spring-gift-product (이전 구현)

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@
 
 - [x] 회원 login, register 페이지 구현
 - [x] cookie 기반 토큰 인터셉터 처리 로직 구현
-- [ ] 상품 목록 조회, 장바구니 등록 domain, repository 설계
-- [ ] 상품 목록 조회, 장바구니 등록 service, controller 설계
+- [x] 위시 리스트 domain, repository 설계
+- [ ] 위시 리스트 service, controller 설계
 - [ ] 위시 리스트 페이지 구현
+- [ ] 회원 수정, 삭제에 필요한 service, repository 추가 구현
+- [ ] 회원 수정, 삭제 페이지 구현
 - [ ] 암호화 적용하기
 
 # spring-gift-product (이전 구현)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 - [x] cookie 기반 토큰 인터셉터 처리 로직 구현
 - [x] 위시 리스트 domain, repository 설계
 - [x] 위시 리스트 service, controller 설계
-- [ ] 위시 리스트 페이지 구현
+- [x] 위시 리스트 페이지 구현
 - [ ] 상품 관리 관리자 페이지 접근 권한 검증
 - [ ] 회원 수정, 삭제에 필요한 service, repository 추가 구현
 - [ ] 회원 수정, 삭제 페이지 구현

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [x] JWT 관련 deprecated 메소드 사용 제거
 - [x] Interceptor: authHeader 토큰 문제 수정
 - [x] Member register, login 테스트 코드 작성
+- [x] 테스트 코드 메소드 추출, 불필요한 코드 제거
 
 # spring-gift-product (이전 구현)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 ### 3단계 - 위시 리스트
 
 - [x] 회원 login, register 페이지 구현
+- [x] cookie 기반 토큰 인터셉터 처리 로직 구현
 - [ ] 상품 목록 조회, 장바구니 등록 domain, repository 설계
 - [ ] 상품 목록 조회, 장바구니 등록 service, controller 설계
 - [ ] 위시 리스트 페이지 구현

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 ### 3단계 - 위시 리스트
 
-- [ ] 회원 login, register 페이지 구현
+- [x] 회원 login, register 페이지 구현
 - [ ] 상품 목록 조회, 장바구니 등록 domain, repository 설계
 - [ ] 상품 목록 조회, 장바구니 등록 service, controller 설계
 - [ ] 위시 리스트 페이지 구현

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@
 - [x] JWT 인증 필터(인터셉터) 적용
 - [x] 인증 예외 처리 구현
 - [x] 테스트 코드 JWT 인증 추가
-- [ ] 회원 관련 페이지 구현
 
 ### 2단계 - 코드 리뷰 반영
 
@@ -59,6 +58,14 @@
 - [x] Interceptor: authHeader 토큰 문제 수정
 - [x] Member register, login 테스트 코드 작성
 - [x] 테스트 코드 메소드 추출, 불필요한 코드 제거
+
+### 3단계 - 위시 리스트
+
+- [ ] 회원 login, register 페이지 구현
+- [ ] 상품 목록 조회, 장바구니 등록 domain, repository 설계
+- [ ] 상품 목록 조회, 장바구니 등록 service, controller 설계
+- [ ] 위시 리스트 페이지 구현
+- [ ] 암호화 적용하기
 
 # spring-gift-product (이전 구현)
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,45 @@
 
 ## API 명세
 
+### 회원 관리 API
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 요청 (Request) | 응답 (Response)                |
+| :--- | :--- | :--- | :--- |:-----------------------------|
+| 일반 회원가입 | `POST` | `/api/members/register` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
+| 관리자 회원가입 | `POST` | `/api/members/register/admin` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
+| 로그인 | `POST` | `/api/members/login` | Body: `MemberLoginRequest` | **200 OK** Body: JWT 토큰      |
+
+### 상품 관리 View
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명          |
+| :--- | :--- | :--- |:------------|
+| 상품 목록 페이지 | `GET` | `/products` | 전체 상품 목록 조회 |
+
+### 회원 관리 View
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명       |
+| :--- | :--- | :--- |:---------|
+| 로그인 페이지 | `GET` | `/members/login` | 로그인 페이지  |
+| 로그인 처리 | `POST` | `/members/login` | 로그인      |
+| 회원가입 페이지 | `GET` | `/members/register` | 회원가입 페이지 |
+| 회원가입 처리 | `POST` | `/members/register` | 회원가입     |
+| 로그아웃 처리 | `POST` | `/members/logout` | 로그아웃     |
+
+### 홈 View
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명     |
+| :--- | :--- | :--- |:-------|
+| 메인 페이지 | `GET` | `/` | 메인 페이지 |
+
 ### 상품관리 RESTful API
 
-| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 요청 (Request) | 응답 (Response) |
-| :--- | :--- | :--- | :--- | :--- |
-| 상품 등록 | `POST` | `/api/products` | Body: `ProductRequestDto` (상품 정보) | **201 Created** Body 없음 |
-| 전체 상품 조회 | `GET` | `/api/products` | 없음 | **200 OK** Body: `List<ProductResponseDto>` (상품 목록) |
-| 특정 상품 조회 | `GET` | `/api/products/{productId}` | Path: `productId` | **200 OK** Body: `ProductResponseDto` (상품 상세 정보) |
-| 상품 정보 수정 | `PUT` | `/api/products/{productId}` | Path: `productId` Body: `ProductRequestDto` (수정할 상품 정보) | **204 No Content** Body 없음 |
-| 상품 삭제 | `DELETE` | `/api/products/{productId}` | Path: `productId` (상품 ID) | **204 No Content** Body 없음 |
+| 기능 | HTTP Method | 엔드포인트 (Endpoint)                  | 요청 (Request) | 응답 (Response) |
+| :--- | :--- |:----------------------------------| :--- | :--- |
+| 상품 등록 | `POST` | `/api/admin/products`             | Body: `ProductRequestDto` (상품 정보) | **201 Created** Body 없음 |
+| 전체 상품 조회 | `GET` | `/api/admin/products`             | 없음 | **200 OK** Body: `List<ProductResponseDto>` (상품 목록) |
+| 특정 상품 조회 | `GET` | `/api/admin/products/{productId}` | Path: `productId` | **200 OK** Body: `ProductResponseDto` (상품 상세 정보) |
+| 상품 정보 수정 | `PUT` | `/api/admin/products/{productId}` | Path: `productId` Body: `ProductRequestDto` (수정할 상품 정보) | **204 No Content** Body 없음 |
+| 상품 삭제 | `DELETE` | `/api/admin/products/{productId}` | Path: `productId` (상품 ID) | **204 No Content** Body 없음 |
 
 ### 상품관리 관리자 View
 | 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명 |
@@ -20,6 +50,8 @@
 | 상품 추가 | `POST` | `/admin/product/add` | 새 상품 등록 |
 | 상품 수정 | `POST` | `/admin/product/edit/{productId}` | 상품 정보 수정 |
 | 상품 삭제 | `DELETE` | `/admin/product/{productId}` | 상품 삭제 |
+
+
 
 ## 위시 리스트 - 요청과 응답 심화
 
@@ -66,7 +98,7 @@
 - [x] 위시 리스트 domain, repository 설계
 - [x] 위시 리스트 service, controller 설계
 - [x] 위시 리스트 페이지 구현
-- [ ] 상품 관리 관리자 페이지 접근 권한 검증
+- [x] 상품 관리 관리자 페이지 접근 권한 검증
 - [ ] 회원 수정, 삭제에 필요한 service, repository 추가 구현
 - [ ] 회원 수정, 삭제 페이지 구현
 - [ ] 암호화 적용하기

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@
 - [x] 회원 login, register 페이지 구현
 - [x] cookie 기반 토큰 인터셉터 처리 로직 구현
 - [x] 위시 리스트 domain, repository 설계
-- [ ] 위시 리스트 service, controller 설계
+- [x] 위시 리스트 service, controller 설계
 - [ ] 위시 리스트 페이지 구현
+- [ ] 상품 관리 관리자 페이지 접근 권한 검증
 - [ ] 회원 수정, 삭제에 필요한 service, repository 추가 구현
 - [ ] 회원 수정, 삭제 페이지 구현
 - [ ] 암호화 적용하기

--- a/README.md
+++ b/README.md
@@ -2,45 +2,31 @@
 
 ## API 명세
 
-### 회원 관리 API
-
-| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 요청 (Request) | 응답 (Response)                |
-| :--- | :--- | :--- | :--- |:-----------------------------|
-| 일반 회원가입 | `POST` | `/api/members/register` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
-| 관리자 회원가입 | `POST` | `/api/members/register/admin` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
-| 로그인 | `POST` | `/api/members/login` | Body: `MemberLoginRequest` | **200 OK** Body: JWT 토큰      |
-
-### 상품 관리 View
-
-| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명          |
-| :--- | :--- | :--- |:------------|
-| 상품 목록 페이지 | `GET` | `/products` | 전체 상품 목록 조회 |
-
-### 회원 관리 View
-
-| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명       |
-| :--- | :--- | :--- |:---------|
-| 로그인 페이지 | `GET` | `/members/login` | 로그인 페이지  |
-| 로그인 처리 | `POST` | `/members/login` | 로그인      |
-| 회원가입 페이지 | `GET` | `/members/register` | 회원가입 페이지 |
-| 회원가입 처리 | `POST` | `/members/register` | 회원가입     |
-| 로그아웃 처리 | `POST` | `/members/logout` | 로그아웃     |
-
 ### 홈 View
 
 | 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명     |
 | :--- | :--- | :--- |:-------|
 | 메인 페이지 | `GET` | `/` | 메인 페이지 |
 
-### 상품관리 RESTful API
+### 회원 관리 View
 
-| 기능 | HTTP Method | 엔드포인트 (Endpoint)                  | 요청 (Request) | 응답 (Response) |
-| :--- | :--- |:----------------------------------| :--- | :--- |
-| 상품 등록 | `POST` | `/api/admin/products`             | Body: `ProductRequestDto` (상품 정보) | **201 Created** Body 없음 |
-| 전체 상품 조회 | `GET` | `/api/admin/products`             | 없음 | **200 OK** Body: `List<ProductResponseDto>` (상품 목록) |
-| 특정 상품 조회 | `GET` | `/api/admin/products/{productId}` | Path: `productId` | **200 OK** Body: `ProductResponseDto` (상품 상세 정보) |
-| 상품 정보 수정 | `PUT` | `/api/admin/products/{productId}` | Path: `productId` Body: `ProductRequestDto` (수정할 상품 정보) | **204 No Content** Body 없음 |
-| 상품 삭제 | `DELETE` | `/api/admin/products/{productId}` | Path: `productId` (상품 ID) | **204 No Content** Body 없음 |
+| 기능          | HTTP Method | 엔드포인트 (Endpoint)    | 설명          |
+|:------------|:------------|:--------------------|:------------|
+| 로그인 페이지     | `GET`       | `/members/login`    | 로그인 페이지     |
+| 로그인 처리      | `POST`      | `/members/login`    | 로그인         |
+| 회원가입 페이지    | `GET`       | `/members/register` | 회원가입 페이지    |
+| 회원가입 처리     | `POST`      | `/members/register` | 회원가입        |
+| 로그아웃 처리     | `POST`      | `/members/logout`   | 로그아웃        |
+| 마이페이지       | `GET`       | `/members/mypage`   | 마이페이지 조회    |
+| 비밀번호 변경 페이지 | `GET`       | `/members/edit`     | 비밀번호 변경 페이지 |
+| 비밀번호 변경     | `POST`      | `/members/edit`     | 비밀번호 변경 처리  |
+| 회원 탈퇴       | `POST`      | `/members/delete`   | 회원 탈퇴 처리    |
+
+### 상품 관리 View
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명          |
+| :--- | :--- | :--- |:------------|
+| 상품 목록 페이지 | `GET` | `/products` | 전체 상품 목록 조회 |
 
 ### 상품관리 관리자 View
 | 기능 | HTTP Method | 엔드포인트 (Endpoint) | 설명 |
@@ -51,7 +37,24 @@
 | 상품 수정 | `POST` | `/admin/product/edit/{productId}` | 상품 정보 수정 |
 | 상품 삭제 | `DELETE` | `/admin/product/{productId}` | 상품 삭제 |
 
+### 회원 관리 API
 
+| 기능 | HTTP Method | 엔드포인트 (Endpoint) | 요청 (Request) | 응답 (Response)                |
+| :--- | :--- | :--- | :--- |:-----------------------------|
+| 일반 회원가입 | `POST` | `/api/members/register` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
+| 관리자 회원가입 | `POST` | `/api/members/register/admin` | Body: `MemberRegisterRequest` | **201 Created** Body: JWT 토큰 |
+| 로그인 | `POST` | `/api/members/login` | Body: `MemberLoginRequest` | **200 OK** Body: JWT 토큰      |
+
+
+### 상품관리 RESTful API
+
+| 기능 | HTTP Method | 엔드포인트 (Endpoint)                  | 요청 (Request) | 응답 (Response) |
+| :--- | :--- |:----------------------------------| :--- | :--- |
+| 상품 등록 | `POST` | `/api/admin/products`             | Body: `ProductRequestDto` (상품 정보) | **201 Created** Body 없음 |
+| 전체 상품 조회 | `GET` | `/api/admin/products`             | 없음 | **200 OK** Body: `List<ProductResponseDto>` (상품 목록) |
+| 특정 상품 조회 | `GET` | `/api/admin/products/{productId}` | Path: `productId` | **200 OK** Body: `ProductResponseDto` (상품 상세 정보) |
+| 상품 정보 수정 | `PUT` | `/api/admin/products/{productId}` | Path: `productId` Body: `ProductRequestDto` (수정할 상품 정보) | **204 No Content** Body 없음 |
+| 상품 삭제 | `DELETE` | `/api/admin/products/{productId}` | Path: `productId` (상품 ID) | **204 No Content** Body 없음 |
 
 ## 위시 리스트 - 요청과 응답 심화
 
@@ -102,6 +105,13 @@
 - [x] 회원 수정, 삭제에 필요한 service, repository 추가 구현
 - [x] 회원 수정, 삭제 페이지 구현
 - [ ] 암호화 적용하기
+
+### 3단계 - 코드 리뷰 반영
+
+- [x] wish service, repository, controller 피드백 내용 수정
+- [x] AccessDeniedException 제거 후 적절한 커스텀 예외 도입
+- [ ] Interceptor 간 의존성 제거하기
+
 
 # spring-gift-product (이전 구현)
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@
 
 - [x] wish service, repository, controller 피드백 내용 수정
 - [x] AccessDeniedException 제거 후 적절한 커스텀 예외 도입
-- [ ] Interceptor 간 의존성 제거하기
-
+- [x] Interceptor 간 의존성 제거하기
 
 # spring-gift-product (이전 구현)
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // thymeleaf layout
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/gift/advice/GlobalExceptionHandler.java
+++ b/src/main/java/gift/advice/GlobalExceptionHandler.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -40,6 +42,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String, String>> handleNoSuchElementException(NoSuchElementException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDeniedException(AccessDeniedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
                 .body(Map.of("error", ex.getMessage()));
     }
 }

--- a/src/main/java/gift/advice/GlobalExceptionHandler.java
+++ b/src/main/java/gift/advice/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package gift.advice;
 
 import gift.product.exception.ProductNotFoundException;
+import gift.wish.exception.WishOwnerException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -18,9 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ProductNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleProductNotFound(ProductNotFoundException ex){
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(Map.of("error", ex.getMessage()));
+        return makeErrorResponseEntity(ex, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -40,22 +40,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", ex.getMessage()));
+        return makeErrorResponseEntity(ex, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<Map<String, String>> handleNoSuchElementException(NoSuchElementException ex) {
+        return makeErrorResponseEntity(ex, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(WishOwnerException.class)
+    public ResponseEntity<Map<String, String>> handleWishOwnerException(WishOwnerException ex) {
+        return makeErrorResponseEntity(ex, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<Map<String, String>> handleDataAccessException(DataAccessException ex) {
+        return makeErrorResponseEntity(ex, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    ResponseEntity<Map<String, String>> makeErrorResponseEntity(Exception ex, HttpStatus status) {
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(status)
                 .body(Map.of("error", ex.getMessage()));
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<Map<String, String>> handleAccessDeniedException(AccessDeniedException ex) {
-        return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(Map.of("error", ex.getMessage()));
-    }
 }

--- a/src/main/java/gift/auth/AdminInterceptor.java
+++ b/src/main/java/gift/auth/AdminInterceptor.java
@@ -1,0 +1,42 @@
+package gift.auth;
+
+import gift.member.domain.Member;
+import gift.member.domain.RoleType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class AdminInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        boolean isApiRequest = request.getRequestURI().startsWith("/api");
+
+        Member member = (Member) request.getAttribute("member");
+
+        if(member == null || member.getRole() != RoleType.ADMIN) {
+            return handleAuthError(response, isApiRequest, "관리자 권한이 필요합니다.");
+        }
+
+        return true;
+    }
+
+    private boolean handleAuthError(HttpServletResponse response, boolean isApiRequest, String msg) throws IOException {
+        if (isApiRequest) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            String jsonMsg = String.format("{\"error\": \"%s\"}", msg);
+            response.getWriter().write(jsonMsg);
+        }
+        else {
+            String encodedMsg = URLEncoder.encode(msg, StandardCharsets.UTF_8);
+            response.sendRedirect("/members/login?error=true&message=" + encodedMsg);
+        }
+        return false;
+    }
+}

--- a/src/main/java/gift/auth/AdminInterceptor.java
+++ b/src/main/java/gift/auth/AdminInterceptor.java
@@ -13,30 +13,21 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 public class AdminInterceptor implements HandlerInterceptor {
+
+    private JwtUtil jwtUtil;
+
+    public AdminInterceptor(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        boolean isApiRequest = request.getRequestURI().startsWith("/api");
+        String token = AuthUtil.extractToken(request);
 
-        Member member = (Member) request.getAttribute("member");
-
-        if(member == null || member.getRole() != RoleType.ADMIN) {
-            return handleAuthError(response, isApiRequest, "관리자 권한이 필요합니다.");
+        if(jwtUtil.getRoleType(token) != RoleType.ADMIN) {
+            AuthUtil.handleAuthError(request, response, "관리자 권한이 필요합니다.");
+            return false;
         }
 
         return true;
-    }
-
-    private boolean handleAuthError(HttpServletResponse response, boolean isApiRequest, String msg) throws IOException {
-        if (isApiRequest) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
-            String jsonMsg = String.format("{\"error\": \"%s\"}", msg);
-            response.getWriter().write(jsonMsg);
-        }
-        else {
-            String encodedMsg = URLEncoder.encode(msg, StandardCharsets.UTF_8);
-            response.sendRedirect("/members/login?error=true&message=" + encodedMsg);
-        }
-        return false;
     }
 }

--- a/src/main/java/gift/auth/AuthUtil.java
+++ b/src/main/java/gift/auth/AuthUtil.java
@@ -1,0 +1,48 @@
+package gift.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class AuthUtil {
+    static String extractToken(HttpServletRequest request) {
+        if (isApiRequest(request)) {
+            String authHeader = request.getHeader("Authorization");
+            if(authHeader != null && authHeader.startsWith("Bearer ")) {
+                return authHeader.substring(7);
+            }
+        }
+        else {
+            Cookie[] cookies = request.getCookies();
+            if(cookies != null) {
+                for (Cookie cookie : request.getCookies()) {
+                    if ("jwt-token".equals(cookie.getName())) {
+                        return cookie.getValue();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    static void handleAuthError(HttpServletRequest request, HttpServletResponse response, String msg) throws IOException {
+        if (isApiRequest(request)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            String jsonMsg = String.format("{\"error\": \"%s\"}", msg);
+            response.getWriter().write(jsonMsg);
+        }
+        else {
+            String encodedMsg = URLEncoder.encode(msg, StandardCharsets.UTF_8);
+            response.sendRedirect("/members/login?error=true&message=" + encodedMsg);
+        }
+    }
+
+    private static boolean isApiRequest(HttpServletRequest request) {
+        return request.getRequestURI().startsWith("/api");
+    }
+}

--- a/src/main/java/gift/auth/JwtUtil.java
+++ b/src/main/java/gift/auth/JwtUtil.java
@@ -18,9 +18,9 @@ public class JwtUtil {
     private final long timeoutMs;
 
     public JwtUtil(@Value("${jwt.secret}") String secretKey,
-                   @Value("${jwt.tokenTimeoutSec}") long timeOut_s) {
+                   @Value("${jwt.tokenTimeoutSec}") long timeOutSec) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-        this.timeoutMs = timeOut_s * 1000;
+        this.timeoutMs = timeOutSec * 1000;
     }
 
     public String generateToken(Member member) {

--- a/src/main/java/gift/auth/JwtUtil.java
+++ b/src/main/java/gift/auth/JwtUtil.java
@@ -1,6 +1,7 @@
 package gift.auth;
 
 import gift.member.domain.Member;
+import gift.member.domain.RoleType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -38,6 +39,11 @@ public class JwtUtil {
 
     public String getEmail(String token) {
         return getClaims(token).getSubject();
+    }
+
+    public RoleType getRoleType(String token) {
+        String roleStr = getClaims(token).get("role", String.class);
+        return RoleType.valueOf(roleStr);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/gift/auth/LoginArgumentResolver.java
+++ b/src/main/java/gift/auth/LoginArgumentResolver.java
@@ -1,6 +1,7 @@
 package gift.auth;
 
 import gift.member.domain.Member;
+import gift.member.dto.MemberTokenRequest;
 import gift.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -26,7 +27,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(Login.class)
-                && parameter.getParameterType().equals(Member.class);
+                && parameter.getParameterType().equals(MemberTokenRequest.class);
     }
 
     @Override
@@ -37,7 +38,9 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
         String token = AuthUtil.extractToken(request);
 
         String email = jwtUtil.getEmail(token);
-        return memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("토큰에 해당하는 사용자를 찾을 수 없습니다."));
+
+        return new MemberTokenRequest(member.getId(), member.getEmail(), member.getPassword(), member.getRole());
     }
 }

--- a/src/main/java/gift/auth/LoginArgumentResolver.java
+++ b/src/main/java/gift/auth/LoginArgumentResolver.java
@@ -1,6 +1,7 @@
 package gift.auth;
 
 import gift.member.domain.Member;
+import gift.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -9,8 +10,18 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.util.Optional;
+
 @Component
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    public LoginArgumentResolver(JwtUtil jwtUtil, MemberRepository memberRepository) {
+        this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -23,6 +34,10 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory){
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        return request.getAttribute("member");
+        String token = AuthUtil.extractToken(request);
+
+        String email = jwtUtil.getEmail(token);
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("토큰에 해당하는 사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/gift/auth/LoginInterceptor.java
+++ b/src/main/java/gift/auth/LoginInterceptor.java
@@ -44,6 +44,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         }
 
         request.setAttribute("member", member.get());
+        request.setAttribute("isLoggedIn", Boolean.TRUE);
 
         return true;
     }

--- a/src/main/java/gift/auth/LoginInterceptor.java
+++ b/src/main/java/gift/auth/LoginInterceptor.java
@@ -16,70 +16,26 @@ import java.util.Optional;
 @Component
 public class LoginInterceptor implements HandlerInterceptor {
     private final JwtUtil jwtUtil;
-    private final MemberRepository memberRepository;
 
-    public LoginInterceptor(JwtUtil jwtUtil, MemberRepository memberRepository) {
+    public LoginInterceptor(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
-        this.memberRepository = memberRepository;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        boolean isApiRequest = request.getRequestURI().startsWith("/api");
 
-        String token = extractToken(request, isApiRequest);
+        String token = AuthUtil.extractToken(request);
 
         if (token == null) {
-            return handleAuthError(response, isApiRequest, "인증 정보가 없습니다. 다시 로그인해주세요");
+            AuthUtil.handleAuthError(request, response, "인증 정보가 없습니다. 다시 로그인해주세요");
+            return false;
         }
 
         if (!jwtUtil.validateToken(token)) {
-            return handleAuthError(response, isApiRequest, "인증 정보가 유효하지 않거나 만료되었습니다. 다시 로그인해주세요.");
+            AuthUtil.handleAuthError(request, response, "인증 정보가 유효하지 않거나 만료되었습니다. 다시 로그인해주세요.");
+            return false;
         }
-
-        String email = jwtUtil.getEmail(token);
-        Optional<Member> member = memberRepository.findByEmail(email);
-        if (member.isEmpty()) {
-            return handleAuthError(response, isApiRequest, "사용자를 찾을 수 없습니다.");
-        }
-
-        request.setAttribute("member", member.get());
         request.setAttribute("isLoggedIn", Boolean.TRUE);
-
         return true;
-    }
-
-    private String extractToken(HttpServletRequest request, boolean isApiRequest) {
-        if (isApiRequest) {
-            String authHeader = request.getHeader("Authorization");
-            if(authHeader != null && authHeader.startsWith("Bearer ")) {
-                return authHeader.substring(7);
-            }
-        }
-        else {
-            Cookie[] cookies = request.getCookies();
-            if(cookies != null) {
-                for (Cookie cookie : request.getCookies()) {
-                    if ("jwt-token".equals(cookie.getName())) {
-                        return cookie.getValue();
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    private boolean handleAuthError(HttpServletResponse response, boolean isApiRequest, String msg) throws IOException {
-        if (isApiRequest) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
-            String jsonMsg = String.format("{\"error\": \"%s\"}", msg);
-            response.getWriter().write(jsonMsg);
-        }
-        else {
-            String encodedMsg = URLEncoder.encode(msg, StandardCharsets.UTF_8);
-            response.sendRedirect("/members/login?error=true&message=" + encodedMsg);
-        }
-        return false;
     }
 }

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -1,5 +1,6 @@
 package gift.config;
 
+import gift.auth.AdminInterceptor;
 import gift.auth.LoginInterceptor;
 import gift.auth.LoginArgumentResolver;
 import org.springframework.context.annotation.Configuration;
@@ -13,27 +14,33 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;
+    private final AdminInterceptor adminInterceptor;
     private final LoginArgumentResolver loginArgumentResolver;
 
-    public WebConfig(LoginInterceptor loginInterceptor, LoginArgumentResolver loginArgumentResolver) {
+    public WebConfig(LoginInterceptor loginInterceptor, AdminInterceptor adminInterceptor, LoginArgumentResolver loginArgumentResolver) {
         this.loginInterceptor = loginInterceptor;
+        this.adminInterceptor = adminInterceptor;
         this.loginArgumentResolver = loginArgumentResolver;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
+                .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns(
                         "/api/members/register",
+                        "/api/members/register/admin",
                         "/api/members/login",
                         "/members/register",
                         "/members/login",
                         "/",
                         "/h2-console/**"
-                        //"/admin/**" // 추후 제거 필요.
-                        //"/api/products/**" // 추후 제거 필요.
                 );
+
+        registry.addInterceptor(adminInterceptor)
+                .order(2)
+                .addPathPatterns("/admin/**", "/api/admin/**");
     }
 
     @Override

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -27,6 +27,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/members/register",
                         "/api/members/login",
+                        "/members/register",
+                        "/members/login",
                         "/h2-console/**"
                         //"/admin/**" // 추후 제거 필요.
                         //"/api/products/**" // 추후 제거 필요.

--- a/src/main/java/gift/config/WebConfig.java
+++ b/src/main/java/gift/config/WebConfig.java
@@ -29,6 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/members/login",
                         "/members/register",
                         "/members/login",
+                        "/",
                         "/h2-console/**"
                         //"/admin/**" // 추후 제거 필요.
                         //"/api/products/**" // 추후 제거 필요.

--- a/src/main/java/gift/home/controller/HomeController.java
+++ b/src/main/java/gift/home/controller/HomeController.java
@@ -1,0 +1,13 @@
+package gift.home.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String homePage() {
+        return "home/home";
+    }
+}

--- a/src/main/java/gift/member/controller/MemberApiController.java
+++ b/src/main/java/gift/member/controller/MemberApiController.java
@@ -28,6 +28,13 @@ public class MemberApiController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @PostMapping("/register/admin")
+    public ResponseEntity<MemberTokenResponse> registerAdmin(@Valid @RequestBody MemberRegisterRequest request) {
+        MemberTokenResponse response = memberService.registerAdmin(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
     @PostMapping("/login")
     public ResponseEntity<MemberTokenResponse> login(@RequestBody MemberLoginRequest request) {
         MemberTokenResponse response = memberService.login(request);

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
 
     @GetMapping("/login")
     public String loginForm(Model model) {
-        model.addAttribute(MemberLoginRequest.getEmpty());
+        model.addAttribute("member", MemberLoginRequest.getEmpty());
 
         return "/members/login";
     }

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
         MemberTokenResponse tokenResponse = memberService.register(registerRequest);
         addTokenCookie(response, tokenResponse.token());
 
-        return "/redirect:/products";
+        return "redirect:/products";
     }
 
     @PostMapping("/logout")

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -33,7 +33,10 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public String login(@ModelAttribute("member") MemberLoginRequest loginRequest, HttpServletResponse response){
+    public String login(@ModelAttribute("member") MemberLoginRequest loginRequest, HttpServletResponse response, BindingResult bindingResult){
+        if(bindingResult.hasErrors()) {
+            return "/members/login";
+        }
         MemberTokenResponse tokenResponse = memberService.login(loginRequest);
 
         addTokenCookie(response, tokenResponse.token());

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -1,8 +1,11 @@
 package gift.member.controller;
 
+import gift.auth.Login;
+import gift.member.domain.Member;
 import gift.member.dto.MemberLoginRequest;
 import gift.member.dto.MemberRegisterRequest;
 import gift.member.dto.MemberTokenResponse;
+import gift.member.dto.MemberUpdateRequest;
 import gift.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,10 +13,7 @@ import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/members")
@@ -65,6 +65,39 @@ public class MemberController {
 
     @PostMapping("/logout")
     public String logout(HttpServletResponse response) {
+        expireTokenCookie(response);
+
+        return "redirect:/";
+    }
+
+    @GetMapping("/mypage")
+    public String mypage(@Login Member member, Model model) {
+        model.addAttribute("member", member);
+
+        return "members/mypage";
+    }
+
+    @GetMapping("/edit")
+    public String editPassword(@Login Member member, Model model) {
+        model.addAttribute("member", MemberUpdateRequest.getEmpty());
+
+        return "members/edit-password-form";
+    }
+
+    @PostMapping("/edit")
+    public String editPassword(@Login Member member, @Valid @ModelAttribute("member") MemberUpdateRequest request, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "members/edit-password-form";
+        }
+
+        memberService.updatePassword(member, request);
+
+        return "redirect:/members/mypage";
+    }
+
+    @PostMapping("/delete")
+    public String deleteMember(@Login Member member, @RequestParam String password, HttpServletResponse response) {
+        memberService.deleteMember(member, password);
         expireTokenCookie(response);
 
         return "redirect:/";

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -1,0 +1,84 @@
+package gift.member.controller;
+
+import gift.member.dto.MemberLoginRequest;
+import gift.member.dto.MemberRegisterRequest;
+import gift.member.dto.MemberTokenResponse;
+import gift.member.service.MemberService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/login")
+    public String loginForm(Model model) {
+        model.addAttribute(MemberLoginRequest.getEmpty());
+
+        return "/members/login";
+    }
+
+    @PostMapping("/login")
+    public String login(@ModelAttribute("member") MemberLoginRequest loginRequest, HttpServletResponse response){
+        MemberTokenResponse tokenResponse = memberService.login(loginRequest);
+
+        addTokenCookie(response, tokenResponse.token());
+        return "redirect:/products";
+    }
+
+    @GetMapping("/register")
+    public String registerForm(Model model) {
+        model.addAttribute("member", MemberRegisterRequest.getEmpty());
+
+        return "/members/register";
+    }
+
+    @PostMapping("/register")
+    public String register(@Valid @ModelAttribute("member") MemberRegisterRequest registerRequest,
+                           BindingResult bindingResult, HttpServletResponse response) {
+        if(bindingResult.hasErrors()) {
+            return "members/register";
+        }
+
+        MemberTokenResponse tokenResponse = memberService.register(registerRequest);
+        addTokenCookie(response, tokenResponse.token());
+
+        return "/redirect:/products";
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpServletResponse response) {
+        expireTokenCookie(response);
+
+        return "redirect:/";
+    }
+
+    private void addTokenCookie(HttpServletResponse response, String token) {
+        Cookie cookie = new Cookie("jwt-token", token);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(60 * 60);
+        response.addCookie(cookie);
+    }
+
+    private void expireTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("jwt-token", null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -2,10 +2,7 @@ package gift.member.controller;
 
 import gift.auth.Login;
 import gift.member.domain.Member;
-import gift.member.dto.MemberLoginRequest;
-import gift.member.dto.MemberRegisterRequest;
-import gift.member.dto.MemberTokenResponse;
-import gift.member.dto.MemberUpdateRequest;
+import gift.member.dto.*;
 import gift.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -71,33 +68,33 @@ public class MemberController {
     }
 
     @GetMapping("/mypage")
-    public String mypage(@Login Member member, Model model) {
-        model.addAttribute("member", member);
+    public String mypage(@Login MemberTokenRequest memberTokenRequest, Model model) {
+        model.addAttribute("member", memberTokenRequest);
 
         return "members/mypage";
     }
 
     @GetMapping("/edit")
-    public String editPassword(@Login Member member, Model model) {
-        model.addAttribute("member", MemberUpdateRequest.getEmpty());
+    public String editPassword(@Login MemberTokenRequest memberTokenRequest, Model model) {
+        model.addAttribute("member", MemberUpdateRequest.getEmpty(memberTokenRequest.id()));
 
         return "members/edit-password-form";
     }
 
     @PostMapping("/edit")
-    public String editPassword(@Login Member member, @Valid @ModelAttribute("member") MemberUpdateRequest request, BindingResult bindingResult) {
+    public String editPassword(@Login MemberTokenRequest memberTokenRequest, @Valid @ModelAttribute("member") MemberUpdateRequest request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "members/edit-password-form";
         }
 
-        memberService.updatePassword(member, request);
+        memberService.updatePassword(memberTokenRequest, request);
 
         return "redirect:/members/mypage";
     }
 
     @PostMapping("/delete")
-    public String deleteMember(@Login Member member, @RequestParam String password, HttpServletResponse response) {
-        memberService.deleteMember(member, password);
+    public String deleteMember(@Login MemberTokenRequest memberTokenRequest, @RequestParam String password, HttpServletResponse response) {
+        memberService.deleteMember(memberTokenRequest, password);
         expireTokenCookie(response);
 
         return "redirect:/";

--- a/src/main/java/gift/member/dto/MemberLoginRequest.java
+++ b/src/main/java/gift/member/dto/MemberLoginRequest.java
@@ -4,5 +4,10 @@ public record MemberLoginRequest(
         String email,
         String password
 ) {
+    private static final String DEFAULT_EMAIL = "";
+    private static final String DEFAULT_PASSWORD = "";
 
+    public static MemberLoginRequest getEmpty() {
+        return new MemberLoginRequest(DEFAULT_EMAIL, DEFAULT_PASSWORD);
+    }
 }

--- a/src/main/java/gift/member/dto/MemberRegisterRequest.java
+++ b/src/main/java/gift/member/dto/MemberRegisterRequest.java
@@ -13,5 +13,9 @@ public record MemberRegisterRequest(
         @Size(min = 4, message = "비밀번호는 최소 4자리 이상이어야 합니다.")
         String password
 ) {
-
+    private static final String DEFAULT_EMAIL = "";
+    private static final String DEFAULT_PASSWORD = "";
+    public static MemberRegisterRequest getEmpty() {
+            return new MemberRegisterRequest(DEFAULT_EMAIL, DEFAULT_PASSWORD);
+    }
 }

--- a/src/main/java/gift/member/dto/MemberTokenRequest.java
+++ b/src/main/java/gift/member/dto/MemberTokenRequest.java
@@ -1,0 +1,10 @@
+package gift.member.dto;
+
+import gift.member.domain.RoleType;
+
+public record MemberTokenRequest (
+        Long id,
+        String email,
+        String password,
+        RoleType role
+) {}

--- a/src/main/java/gift/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/gift/member/dto/MemberUpdateRequest.java
@@ -7,13 +7,14 @@ import jakarta.validation.constraints.Size;
 public record MemberUpdateRequest(
         @NotNull
         Long id,
+        String password,
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 4, message = "비밀번호는 최소 4자리 이상이어야 합니다.")
-        String password
+        String newPassword
 ) {
     private static final Long DEFAULT_ID = null;
     private static final String DEFAULT_PASSWORD = "";
     public static MemberUpdateRequest getEmpty() {
-        return new MemberUpdateRequest(DEFAULT_ID, DEFAULT_PASSWORD);
+        return new MemberUpdateRequest(DEFAULT_ID, DEFAULT_PASSWORD, DEFAULT_PASSWORD);
     }
 }

--- a/src/main/java/gift/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/gift/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,19 @@
+package gift.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record MemberUpdateRequest(
+        @NotNull
+        Long id,
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 4, message = "비밀번호는 최소 4자리 이상이어야 합니다.")
+        String password
+) {
+    private static final Long DEFAULT_ID = null;
+    private static final String DEFAULT_PASSWORD = "";
+    public static MemberUpdateRequest getEmpty() {
+        return new MemberUpdateRequest(DEFAULT_ID, DEFAULT_PASSWORD);
+    }
+}

--- a/src/main/java/gift/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/gift/member/dto/MemberUpdateRequest.java
@@ -12,9 +12,8 @@ public record MemberUpdateRequest(
         @Size(min = 4, message = "비밀번호는 최소 4자리 이상이어야 합니다.")
         String newPassword
 ) {
-    private static final Long DEFAULT_ID = null;
     private static final String DEFAULT_PASSWORD = "";
-    public static MemberUpdateRequest getEmpty() {
-        return new MemberUpdateRequest(DEFAULT_ID, DEFAULT_PASSWORD, DEFAULT_PASSWORD);
+    public static MemberUpdateRequest getEmpty(Long memberId) {
+        return new MemberUpdateRequest(memberId, DEFAULT_PASSWORD, DEFAULT_PASSWORD);
     }
 }

--- a/src/main/java/gift/member/repository/MemberRepository.java
+++ b/src/main/java/gift/member/repository/MemberRepository.java
@@ -38,6 +38,23 @@ public class MemberRepository {
                 .optional();
     }
 
+    public boolean updatePassword(Long id, String newPassword) {
+        int affected = client.sql("update member set password = :password where id = :id")
+                .param("password", newPassword)
+                .param("id", id)
+                .update();
+
+        return affected > 0;
+    }
+
+    public boolean deleteById(Long id) {
+        int affected = client.sql("delete from member where id = :id")
+                .param("id", id)
+                .update();
+
+        return affected > 0;
+    }
+
     private final RowMapper<Member> memberRowMapper = (rs, rowNum) -> new Member(
             rs.getLong("id"),
             rs.getString("email"),

--- a/src/main/java/gift/member/repository/MemberRepository.java
+++ b/src/main/java/gift/member/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Repository
@@ -38,21 +39,21 @@ public class MemberRepository {
                 .optional();
     }
 
-    public boolean updatePassword(Long id, String newPassword) {
+    public void updatePassword(Long id, String newPassword) {
         int affected = client.sql("update member set password = :password where id = :id")
                 .param("password", newPassword)
                 .param("id", id)
                 .update();
 
-        return affected > 0;
+        checkAffected(affected);
     }
 
-    public boolean deleteById(Long id) {
+    public void deleteById(Long id) {
         int affected = client.sql("delete from member where id = :id")
                 .param("id", id)
                 .update();
 
-        return affected > 0;
+        checkAffected(affected);
     }
 
     private final RowMapper<Member> memberRowMapper = (rs, rowNum) -> new Member(
@@ -61,4 +62,10 @@ public class MemberRepository {
             rs.getString("password"),
             RoleType.valueOf(rs.getString("role"))
     );
+
+    private void checkAffected(int affected) {
+        if(affected == 0) {
+            throw new NoSuchElementException("해당 사용자를 찾을 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/gift/member/service/MemberService.java
+++ b/src/main/java/gift/member/service/MemberService.java
@@ -21,11 +21,19 @@ public class MemberService {
     }
 
     public MemberTokenResponse register(MemberRegisterRequest request) {
+        return registerMember(request, RoleType.USER);
+    }
+
+    public MemberTokenResponse registerAdmin(MemberRegisterRequest request) {
+        return registerMember(request, RoleType.ADMIN);
+    }
+
+    private MemberTokenResponse registerMember(MemberRegisterRequest request, RoleType roleType) {
         if(memberRepository.findByEmail(request.email()).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다: " + request.email());
         }
 
-        Member member = memberRepository.save(request.email(), request.password(), RoleType.USER);
+        Member member = memberRepository.save(request.email(), request.password(), roleType);
 
         return new MemberTokenResponse(jwtUtil.generateToken(member));
     }

--- a/src/main/java/gift/member/service/MemberService.java
+++ b/src/main/java/gift/member/service/MemberService.java
@@ -6,6 +6,7 @@ import gift.member.domain.RoleType;
 import gift.member.dto.MemberLoginRequest;
 import gift.member.dto.MemberTokenResponse;
 import gift.member.dto.MemberRegisterRequest;
+import gift.member.dto.MemberUpdateRequest;
 import gift.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -42,10 +43,26 @@ public class MemberService {
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
-        if (!member.getPassword().equals(request.password())){
-           throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
+        checkPassword(member, request.password(), "비밀번호가 일치하지 않습니다.");
 
         return new MemberTokenResponse(jwtUtil.generateToken(member));
+    }
+
+    public void updatePassword(Member member, MemberUpdateRequest request) {
+        checkPassword(member, request.password(), "현재 비밀번호가 일치하지 않습니다.");
+
+        memberRepository.updatePassword(member.getId(), request.password());
+    }
+
+    public void deleteMember(Member member, String password) {
+        checkPassword(member, password, "비밀번호가 일치하지 않습니다.");
+
+        memberRepository.deleteById(member.getId());
+    }
+
+    private void checkPassword(Member member, String password, String msg) {
+        if(member.getPassword().equals(password)) {
+            throw new IllegalArgumentException(msg);
+        }
     }
 }

--- a/src/main/java/gift/member/service/MemberService.java
+++ b/src/main/java/gift/member/service/MemberService.java
@@ -51,7 +51,7 @@ public class MemberService {
     public void updatePassword(Member member, MemberUpdateRequest request) {
         checkPassword(member, request.password(), "현재 비밀번호가 일치하지 않습니다.");
 
-        memberRepository.updatePassword(member.getId(), request.password());
+        memberRepository.updatePassword(member.getId(), request.newPassword());
     }
 
     public void deleteMember(Member member, String password) {
@@ -61,7 +61,7 @@ public class MemberService {
     }
 
     private void checkPassword(Member member, String password, String msg) {
-        if(member.getPassword().equals(password)) {
+        if(!member.getPassword().equals(password)) {
             throw new IllegalArgumentException(msg);
         }
     }

--- a/src/main/java/gift/member/service/MemberService.java
+++ b/src/main/java/gift/member/service/MemberService.java
@@ -3,10 +3,7 @@ package gift.member.service;
 import gift.auth.JwtUtil;
 import gift.member.domain.Member;
 import gift.member.domain.RoleType;
-import gift.member.dto.MemberLoginRequest;
-import gift.member.dto.MemberTokenResponse;
-import gift.member.dto.MemberRegisterRequest;
-import gift.member.dto.MemberUpdateRequest;
+import gift.member.dto.*;
 import gift.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -43,25 +40,25 @@ public class MemberService {
         Member member = memberRepository.findByEmail(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
-        checkPassword(member, request.password(), "비밀번호가 일치하지 않습니다.");
+        checkPassword(member.getPassword(), request.password(), "비밀번호가 일치하지 않습니다.");
 
         return new MemberTokenResponse(jwtUtil.generateToken(member));
     }
 
-    public void updatePassword(Member member, MemberUpdateRequest request) {
-        checkPassword(member, request.password(), "현재 비밀번호가 일치하지 않습니다.");
+    public void updatePassword(MemberTokenRequest memberTokenRequest, MemberUpdateRequest request) {
+        checkPassword(memberTokenRequest.password(), request.password(), "현재 비밀번호가 일치하지 않습니다.");
 
-        memberRepository.updatePassword(member.getId(), request.newPassword());
+        memberRepository.updatePassword(memberTokenRequest.id(), request.newPassword());
     }
 
-    public void deleteMember(Member member, String password) {
-        checkPassword(member, password, "비밀번호가 일치하지 않습니다.");
+    public void deleteMember(MemberTokenRequest memberTokenRequest, String password) {
+        checkPassword(memberTokenRequest.password(), password, "비밀번호가 일치하지 않습니다.");
 
-        memberRepository.deleteById(member.getId());
+        memberRepository.deleteById(memberTokenRequest.id());
     }
 
-    private void checkPassword(Member member, String password, String msg) {
-        if(!member.getPassword().equals(password)) {
+    private void checkPassword(String originPassword, String password, String msg) {
+        if(!originPassword.equals(password)) {
             throw new IllegalArgumentException(msg);
         }
     }

--- a/src/main/java/gift/product/controller/ProductApiAdminController.java
+++ b/src/main/java/gift/product/controller/ProductApiAdminController.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/products")
-public class ProductApiController {
+@RequestMapping("/api/admin/products")
+public class ProductApiAdminController {
 
     private final ProductService productService;
 
-    public ProductApiController(ProductService productService){
+    public ProductApiAdminController(ProductService productService){
         this.productService = productService;
     }
 

--- a/src/main/java/gift/product/controller/ProductController.java
+++ b/src/main/java/gift/product/controller/ProductController.java
@@ -1,0 +1,32 @@
+package gift.product.controller;
+
+import gift.product.dto.ProductInfoDto;
+import gift.product.service.ProductService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/products")
+public class ProductController {
+    private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping
+    public String products(Model model) {
+        List<ProductInfoDto> products = productService.getProducts()
+                .stream()
+                .map(product -> ProductInfoDto.productFrom(product))
+                .toList();
+
+        model.addAttribute("products", products);
+
+        return "products/products";
+    }
+}

--- a/src/main/java/gift/product/repository/JDBCProductRepository.java
+++ b/src/main/java/gift/product/repository/JDBCProductRepository.java
@@ -49,23 +49,27 @@ public class JDBCProductRepository implements ProductRepository{
     }
 
     @Override
-    public void update(Long id, String name, int price, String imageUrl) {
-        client.sql("update product set name = :name, price = :price, image_url = :imageUrl where id = :id")
+    public boolean update(Long id, String name, int price, String imageUrl) {
+        int affected = client.sql("update product set name = :name, price = :price, image_url = :imageUrl where id = :id")
                 .param("name", name)
                 .param("price", price)
                 .param("imageUrl", imageUrl)
                 .param("id", id)
                 .update();
+
+        return affected > 0;
     }
 
     @Override
-    public void deleteById(Long id) {
-        client.sql("delete from product where id = :id")
+    public boolean deleteById(Long id) {
+        int affected = client.sql("delete from product where id = :id")
                 .param("id", id)
                 .update();
+
+        return affected > 0;
     }
 
-    private final RowMapper<Product> productRowMapper = (rs, rowNum) -> new Product(
+    private static final RowMapper<Product> productRowMapper = (rs, rowNum) -> new Product(
             rs.getLong("id"),
             rs.getString("name"),
             rs.getInt("price"),

--- a/src/main/java/gift/product/repository/JDBCProductRepository.java
+++ b/src/main/java/gift/product/repository/JDBCProductRepository.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Repository
@@ -49,24 +50,23 @@ public class JDBCProductRepository implements ProductRepository{
     }
 
     @Override
-    public boolean update(Long id, String name, int price, String imageUrl) {
+    public void update(Long id, String name, int price, String imageUrl) {
         int affected = client.sql("update product set name = :name, price = :price, image_url = :imageUrl where id = :id")
                 .param("name", name)
                 .param("price", price)
                 .param("imageUrl", imageUrl)
                 .param("id", id)
                 .update();
-
-        return affected > 0;
+        checkAffected(affected);
     }
 
     @Override
-    public boolean deleteById(Long id) {
+    public void deleteById(Long id) {
         int affected = client.sql("delete from product where id = :id")
                 .param("id", id)
                 .update();
 
-        return affected > 0;
+        checkAffected(affected);
     }
 
     private static final RowMapper<Product> productRowMapper = (rs, rowNum) -> new Product(
@@ -75,4 +75,10 @@ public class JDBCProductRepository implements ProductRepository{
             rs.getInt("price"),
             rs.getString("image_url")
     );
+
+    private void checkAffected(int affected) {
+        if(affected == 0) {
+            throw new NoSuchElementException("해당 상품 항목을 찾을 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/gift/product/repository/ProductRepository.java
+++ b/src/main/java/gift/product/repository/ProductRepository.java
@@ -13,7 +13,7 @@ public interface ProductRepository {
 
     Optional<Product> findById(Long id);
 
-    void update(Long id, String name, int price, String imageUrl);
+    boolean update(Long id, String name, int price, String imageUrl);
 
-    void deleteById(Long id);
+    boolean deleteById(Long id);
 }

--- a/src/main/java/gift/product/repository/ProductRepository.java
+++ b/src/main/java/gift/product/repository/ProductRepository.java
@@ -13,7 +13,7 @@ public interface ProductRepository {
 
     Optional<Product> findById(Long id);
 
-    boolean update(Long id, String name, int price, String imageUrl);
+    void update(Long id, String name, int price, String imageUrl);
 
-    boolean deleteById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/gift/wish/controller/WishApiController.java
+++ b/src/main/java/gift/wish/controller/WishApiController.java
@@ -1,0 +1,52 @@
+package gift.wish.controller;
+
+import gift.auth.Login;
+import gift.member.domain.Member;
+import gift.wish.dto.WishListResponse;
+import gift.wish.dto.WishRequest;
+import gift.wish.dto.WishUpdateRequest;
+import gift.wish.service.WishService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/wishes")
+public class WishApiController {
+    private final WishService wishService;
+
+    public WishApiController(WishService wishService) {
+        this.wishService = wishService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addWish(@Login Member member, @Valid @RequestBody WishRequest request) {
+        wishService.addWish(member,request.productId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<WishListResponse>> getWishes(@Login Member member) {
+        List<WishListResponse> wishes = wishService.getWishes(member);
+
+        return ResponseEntity.ok(wishes);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateWish(@Login Member member, @RequestBody WishUpdateRequest request) throws AccessDeniedException {
+        wishService.updateQuantity(member, request.wishId(), request.quantity());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{wishId}")
+    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId) throws AccessDeniedException {
+        wishService.deleteWish(member, wishId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/gift/wish/controller/WishApiController.java
+++ b/src/main/java/gift/wish/controller/WishApiController.java
@@ -2,6 +2,7 @@ package gift.wish.controller;
 
 import gift.auth.Login;
 import gift.member.domain.Member;
+import gift.member.dto.MemberTokenRequest;
 import gift.wish.dto.WishListResponse;
 import gift.wish.dto.WishRequest;
 import gift.wish.dto.WishUpdateRequest;
@@ -22,29 +23,29 @@ public class WishApiController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> addWish(@Login Member member, @Valid @RequestBody WishRequest request) {
-        wishService.addWish(member,request.productId());
+    public ResponseEntity<Void> addWish(@Login MemberTokenRequest memberTokenRequest, @Valid @RequestBody WishRequest request) {
+        wishService.addWish(memberTokenRequest ,request.productId());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping
-    public ResponseEntity<List<WishListResponse>> getWishes(@Login Member member) {
-        List<WishListResponse> wishes = wishService.getWishes(member);
+    public ResponseEntity<List<WishListResponse>> getWishes(@Login MemberTokenRequest memberTokenRequest) {
+        List<WishListResponse> wishes = wishService.getWishes(memberTokenRequest);
 
         return ResponseEntity.ok(wishes);
     }
 
     @PatchMapping("/{wishId}")
-    public ResponseEntity<Void> updateWish(@Login Member member, @PathVariable Long wishId, @RequestBody WishUpdateRequest request){
-        wishService.updateQuantity(member, wishId, request.quantity());
+    public ResponseEntity<Void> updateWish(@Login MemberTokenRequest memberTokenRequest, @PathVariable Long wishId, @RequestBody WishUpdateRequest request){
+        wishService.updateQuantity(memberTokenRequest, wishId, request.quantity());
 
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{wishId}")
-    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId){
-        wishService.deleteWish(member, wishId);
+    public ResponseEntity<Void> deleteWish(@Login MemberTokenRequest memberTokenRequest, @PathVariable Long wishId){
+        wishService.deleteWish(memberTokenRequest, wishId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/gift/wish/controller/WishApiController.java
+++ b/src/main/java/gift/wish/controller/WishApiController.java
@@ -10,8 +10,6 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 @RestController
@@ -37,15 +35,15 @@ public class WishApiController {
         return ResponseEntity.ok(wishes);
     }
 
-    @PutMapping
-    public ResponseEntity<Void> updateWish(@Login Member member, @RequestBody WishUpdateRequest request) throws AccessDeniedException {
-        wishService.updateQuantity(member, request.wishId(), request.quantity());
+    @PatchMapping("/{wishId}")
+    public ResponseEntity<Void> updateWish(@Login Member member, @PathVariable Long wishId, @RequestBody WishUpdateRequest request){
+        wishService.updateQuantity(member, wishId, request.quantity());
 
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{wishId}")
-    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId) throws AccessDeniedException {
+    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId){
         wishService.deleteWish(member, wishId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/gift/wish/controller/WishController.java
+++ b/src/main/java/gift/wish/controller/WishController.java
@@ -1,0 +1,52 @@
+package gift.wish.controller;
+
+import gift.auth.Login;
+import gift.member.domain.Member;
+import gift.wish.dto.WishListResponse;
+import gift.wish.dto.WishRequest;
+import gift.wish.dto.WishUpdateRequest;
+import gift.wish.service.WishService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/wishes")
+public class WishController {
+    private final WishService wishService;
+
+    public WishController(WishService wishService) {
+        this.wishService = wishService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addWish(@Login Member member, @Valid @RequestBody WishRequest request) {
+        wishService.addWish(member,request.productId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<WishListResponse>> getWishes(@Login Member member) {
+        List<WishListResponse> wishes = wishService.getWishes(member);
+
+        return ResponseEntity.ok(wishes);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateWish(@Login Member member, @RequestBody WishUpdateRequest request) throws AccessDeniedException {
+        wishService.updateQuantity(member, request.wishId(), request.quantity());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{wishId}")
+    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId) throws AccessDeniedException {
+        wishService.deleteWish(member, wishId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/gift/wish/controller/WishController.java
+++ b/src/main/java/gift/wish/controller/WishController.java
@@ -6,47 +6,46 @@ import gift.wish.dto.WishListResponse;
 import gift.wish.dto.WishRequest;
 import gift.wish.dto.WishUpdateRequest;
 import gift.wish.service.WishService;
-import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 
-@RestController
-@RequestMapping("/api/wishes")
+@Controller
+@RequestMapping("/wishes")
 public class WishController {
-    private final WishService wishService;
+    private WishService wishService;
 
-    public WishController(WishService wishService) {
+    public WishController(WishService wishService){
         this.wishService = wishService;
     }
 
-    @PostMapping
-    public ResponseEntity<Void> addWish(@Login Member member, @Valid @RequestBody WishRequest request) {
-        wishService.addWish(member,request.productId());
-
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
-
     @GetMapping
-    public ResponseEntity<List<WishListResponse>> getWishes(@Login Member member) {
+    public String getwishList(@Login Member member, Model model) {
         List<WishListResponse> wishes = wishService.getWishes(member);
 
-        return ResponseEntity.ok(wishes);
+        model.addAttribute("wishes", wishes);
+        return "wishes/wishes";
     }
 
-    @PutMapping
-    public ResponseEntity<Void> updateWish(@Login Member member, @RequestBody WishUpdateRequest request) throws AccessDeniedException {
-        wishService.updateQuantity(member, request.wishId(), request.quantity());
-
-        return ResponseEntity.noContent().build();
+    @PostMapping("/add")
+    public String addWish(@Login Member member, @ModelAttribute WishRequest request) {
+        wishService.addWish(member, request.productId());
+        return "redirect:/wishes";
     }
 
-    @DeleteMapping("/{wishId}")
-    public ResponseEntity<Void> deleteWish(@Login Member member, @PathVariable Long wishId) throws AccessDeniedException {
+    @PostMapping("/update")
+    public String updateWish(@Login Member member, @ModelAttribute WishUpdateRequest request) throws AccessDeniedException {
+        wishService.updateQuantity(member,request.wishId(), request.quantity());
+
+        return "redirect:/wishes";
+    }
+
+    @PostMapping("/delete/{wishId}")
+    public String deleteWish(@Login Member member, @PathVariable("wishId") Long wishId) throws AccessDeniedException {
         wishService.deleteWish(member, wishId);
-        return ResponseEntity.noContent().build();
+        return "redirect:/wishes";
     }
 }

--- a/src/main/java/gift/wish/controller/WishController.java
+++ b/src/main/java/gift/wish/controller/WishController.java
@@ -9,8 +9,6 @@ import gift.wish.service.WishService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 @Controller
@@ -23,7 +21,7 @@ public class WishController {
     }
 
     @GetMapping
-    public String getwishList(@Login Member member, Model model) {
+    public String getWishes(@Login Member member, Model model) {
         List<WishListResponse> wishes = wishService.getWishes(member);
 
         model.addAttribute("wishes", wishes);
@@ -36,15 +34,15 @@ public class WishController {
         return "redirect:/wishes";
     }
 
-    @PostMapping("/update")
-    public String updateWish(@Login Member member, @ModelAttribute WishUpdateRequest request) throws AccessDeniedException {
-        wishService.updateQuantity(member,request.wishId(), request.quantity());
+    @PostMapping("/update/{wishId}")
+    public String updateWish(@Login Member member, @PathVariable Long wishId, @ModelAttribute WishUpdateRequest request){
+        wishService.updateQuantity(member, wishId, request.quantity());
 
         return "redirect:/wishes";
     }
 
     @PostMapping("/delete/{wishId}")
-    public String deleteWish(@Login Member member, @PathVariable("wishId") Long wishId) throws AccessDeniedException {
+    public String deleteWish(@Login Member member, @PathVariable("wishId") Long wishId) {
         wishService.deleteWish(member, wishId);
         return "redirect:/wishes";
     }

--- a/src/main/java/gift/wish/controller/WishController.java
+++ b/src/main/java/gift/wish/controller/WishController.java
@@ -2,6 +2,7 @@ package gift.wish.controller;
 
 import gift.auth.Login;
 import gift.member.domain.Member;
+import gift.member.dto.MemberTokenRequest;
 import gift.wish.dto.WishListResponse;
 import gift.wish.dto.WishRequest;
 import gift.wish.dto.WishUpdateRequest;
@@ -21,29 +22,29 @@ public class WishController {
     }
 
     @GetMapping
-    public String getWishes(@Login Member member, Model model) {
-        List<WishListResponse> wishes = wishService.getWishes(member);
+    public String getWishes(@Login MemberTokenRequest memberTokenRequest, Model model) {
+        List<WishListResponse> wishes = wishService.getWishes(memberTokenRequest);
 
         model.addAttribute("wishes", wishes);
         return "wishes/wishes";
     }
 
     @PostMapping("/add")
-    public String addWish(@Login Member member, @ModelAttribute WishRequest request) {
-        wishService.addWish(member, request.productId());
+    public String addWish(@Login MemberTokenRequest memberTokenRequest, @ModelAttribute WishRequest request) {
+        wishService.addWish(memberTokenRequest, request.productId());
         return "redirect:/wishes";
     }
 
     @PostMapping("/update/{wishId}")
-    public String updateWish(@Login Member member, @PathVariable Long wishId, @ModelAttribute WishUpdateRequest request){
-        wishService.updateQuantity(member, wishId, request.quantity());
+    public String updateWish(@Login MemberTokenRequest memberTokenRequest, @PathVariable Long wishId, @ModelAttribute WishUpdateRequest request){
+        wishService.updateQuantity(memberTokenRequest, wishId, request.quantity());
 
         return "redirect:/wishes";
     }
 
     @PostMapping("/delete/{wishId}")
-    public String deleteWish(@Login Member member, @PathVariable("wishId") Long wishId) {
-        wishService.deleteWish(member, wishId);
+    public String deleteWish(@Login MemberTokenRequest memberTokenRequest, @PathVariable("wishId") Long wishId) {
+        wishService.deleteWish(memberTokenRequest, wishId);
         return "redirect:/wishes";
     }
 }

--- a/src/main/java/gift/wish/domain/Wish.java
+++ b/src/main/java/gift/wish/domain/Wish.java
@@ -4,11 +4,13 @@ public class Wish {
     private Long id;
     private Long memberId;
     private Long productId;
+    private Integer quantity;
 
-    public Wish(Long id, Long memberId, Long productId) {
+    public Wish(Long id, Long memberId, Long productId, Integer quantity) {
         this.id = id;
         this.memberId = memberId;
         this.productId = productId;
+        this.quantity = quantity;
     }
 
     public Long getId() {
@@ -17,9 +19,5 @@ public class Wish {
 
     public Long getMemberId() {
         return memberId;
-    }
-
-    public Long getProductId() {
-        return productId;
     }
 }

--- a/src/main/java/gift/wish/domain/Wish.java
+++ b/src/main/java/gift/wish/domain/Wish.java
@@ -1,0 +1,25 @@
+package gift.wish.domain;
+
+public class Wish {
+    private Long id;
+    private Long memberId;
+    private Long productId;
+
+    public Wish(Long id, Long memberId, Long productId) {
+        this.id = id;
+        this.memberId = memberId;
+        this.productId = productId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+}

--- a/src/main/java/gift/wish/domain/Wish.java
+++ b/src/main/java/gift/wish/domain/Wish.java
@@ -1,5 +1,7 @@
 package gift.wish.domain;
 
+import gift.wish.exception.WishOwnerException;
+
 public class Wish {
     private Long id;
     private Long memberId;
@@ -19,5 +21,15 @@ public class Wish {
 
     public Long getMemberId() {
         return memberId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void validateOwner(Long memberId) {
+        if(!this.memberId.equals(memberId)) {
+            throw new WishOwnerException("해당 위시 항목을 삭제할 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/gift/wish/dto/WishListResponse.java
+++ b/src/main/java/gift/wish/dto/WishListResponse.java
@@ -1,0 +1,11 @@
+package gift.wish.dto;
+
+public record WishListResponse(
+        Long wishId,
+        Long product_id,
+        String productName,
+        String productImageUrl,
+        Integer quantity
+) {
+
+}

--- a/src/main/java/gift/wish/dto/WishListResponse.java
+++ b/src/main/java/gift/wish/dto/WishListResponse.java
@@ -4,6 +4,7 @@ public record WishListResponse(
         Long wishId,
         Long product_id,
         String productName,
+        Integer productPrice,
         String productImageUrl,
         Integer quantity
 ) {

--- a/src/main/java/gift/wish/dto/WishRequest.java
+++ b/src/main/java/gift/wish/dto/WishRequest.java
@@ -1,0 +1,9 @@
+package gift.wish.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WishRequest(
+        @NotNull
+        Long productId
+) {
+}

--- a/src/main/java/gift/wish/dto/WishResponse.java
+++ b/src/main/java/gift/wish/dto/WishResponse.java
@@ -1,0 +1,8 @@
+package gift.wish.dto;
+
+public record WishResponse(
+        Long memberId,
+        Long productId,
+        int quantity
+) {
+}

--- a/src/main/java/gift/wish/dto/WishUpdateRequest.java
+++ b/src/main/java/gift/wish/dto/WishUpdateRequest.java
@@ -1,0 +1,11 @@
+package gift.wish.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WishUpdateRequest (
+        @NotNull
+        Long wishId,
+        @NotNull
+        Integer quantity
+) {
+}

--- a/src/main/java/gift/wish/dto/WishUpdateRequest.java
+++ b/src/main/java/gift/wish/dto/WishUpdateRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record WishUpdateRequest (
         @NotNull
-        Long wishId,
-        @NotNull
         Integer quantity
 ) {
 }

--- a/src/main/java/gift/wish/exception/WishOwnerException.java
+++ b/src/main/java/gift/wish/exception/WishOwnerException.java
@@ -1,0 +1,7 @@
+package gift.wish.exception;
+
+public class WishOwnerException extends RuntimeException {
+    public WishOwnerException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/gift/wish/repository/WishRepository.java
+++ b/src/main/java/gift/wish/repository/WishRepository.java
@@ -1,0 +1,57 @@
+package gift.wish.repository;
+
+import gift.wish.domain.Wish;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class WishRepository {
+    private final JdbcClient client;
+
+    public WishRepository(JdbcClient client) {
+        this.client = client;
+    }
+
+    public Wish save(Wish wish) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        client.sql("insert into wish (member_id, product_id) values (:memberId, :productId)")
+                .param("memberId", wish.getMemberId())
+                .param("productId", wish.getProductId())
+                .update(keyHolder);
+
+        return new Wish(keyHolder.getKey().longValue(), wish.getMemberId(), wish.getProductId());
+    }
+
+    public Optional<Wish> findById(Long id) {
+        return client.sql("select id, member_id, product_id from wish where id = :id")
+                .param("id", id)
+                .query(wishRowMapper)
+                .optional();
+    }
+
+    public List<Wish> findByMemberId(Long memberId) {
+        return client.sql("select id, member_id, product_id from wish where member_id = :memberId")
+                .param("memberId", memberId)
+                .query(wishRowMapper)
+                .list();
+    }
+
+    public boolean deleteById(Long id) {
+        int affected = client.sql("delete from wish where id = :id")
+                .param("id", id)
+                .update();
+        return affected > 0;
+    }
+
+    private static final RowMapper<Wish> wishRowMapper = (rs, rowNum) -> new Wish(
+            rs.getLong("id"),
+            rs.getLong("member_id"),
+            rs.getLong("product_id")
+    );
+}

--- a/src/main/java/gift/wish/repository/WishRepository.java
+++ b/src/main/java/gift/wish/repository/WishRepository.java
@@ -42,10 +42,11 @@ public class WishRepository {
                         "w.id as wish_id, " +
                         "w.product_id as product_id, " +
                         "p.name as product_name, " +
+                        "p.price as product_price, " +
                         "p.image_url as product_image_url, " +
                         "w.quantity as quantity " +
                         "from wish as w " +
-                        "join product p on w.product_id = p.id" +
+                        "join product p on w.product_id = p.id " +
                         "where member_id = :memberId")
                 .param("memberId", memberId)
                 .query(wishListResponseRowMapper)
@@ -54,6 +55,7 @@ public class WishRepository {
 
     public boolean updateByIdAndQuantity(Long id, Integer quantity) {
         int affected = client.sql("update wish set quantity = :quantity where id = :id")
+                .param("quantity", quantity)
                 .param("id", id)
                 .update();
 
@@ -88,6 +90,7 @@ public class WishRepository {
             rs.getLong("wish_id"),
             rs.getLong("product_id"),
             rs.getString("product_name"),
+            rs.getInt("product_price"),
             rs.getString("product_image_url"),
             rs.getInt("quantity")
     );

--- a/src/main/java/gift/wish/repository/WishRepository.java
+++ b/src/main/java/gift/wish/repository/WishRepository.java
@@ -1,6 +1,7 @@
 package gift.wish.repository;
 
 import gift.wish.domain.Wish;
+import gift.wish.dto.WishListResponse;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -18,28 +19,45 @@ public class WishRepository {
         this.client = client;
     }
 
-    public Wish save(Wish wish) {
+    public Wish save(Long memberId, Long productId) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
-        client.sql("insert into wish (member_id, product_id) values (:memberId, :productId)")
-                .param("memberId", wish.getMemberId())
-                .param("productId", wish.getProductId())
+        client.sql("insert into wish (member_id, product_id, quantity) values (:memberId, :productId, :quantity)")
+                .param("memberId", memberId)
+                .param("productId", productId)
+                .param("quantity", 1)
                 .update(keyHolder);
 
-        return new Wish(keyHolder.getKey().longValue(), wish.getMemberId(), wish.getProductId());
+        return new Wish(keyHolder.getKey().longValue(), memberId, productId, 1);
     }
 
     public Optional<Wish> findById(Long id) {
-        return client.sql("select id, member_id, product_id from wish where id = :id")
+        return client.sql("select id, member_id, product_id, quantity from wish where id = :id")
                 .param("id", id)
                 .query(wishRowMapper)
                 .optional();
     }
 
-    public List<Wish> findByMemberId(Long memberId) {
-        return client.sql("select id, member_id, product_id from wish where member_id = :memberId")
+    public List<WishListResponse> findByMemberId(Long memberId) {
+        return client.sql("select " +
+                        "w.id as wish_id, " +
+                        "w.product_id as product_id, " +
+                        "p.name as product_name, " +
+                        "p.image_url as product_image_url, " +
+                        "w.quantity as quantity " +
+                        "from wish as w " +
+                        "join product p on w.product_id = p.id" +
+                        "where member_id = :memberId")
                 .param("memberId", memberId)
-                .query(wishRowMapper)
+                .query(wishListResponseRowMapper)
                 .list();
+    }
+
+    public boolean updateByIdAndQuantity(Long id, Integer quantity) {
+        int affected = client.sql("update wish set quantity = :quantity where id = :id")
+                .param("id", id)
+                .update();
+
+        return affected > 0;
     }
 
     public boolean deleteById(Long id) {
@@ -49,9 +67,28 @@ public class WishRepository {
         return affected > 0;
     }
 
+    public boolean isExist(Long memberId, Long productId){
+        Integer count = client.sql("select count(*) from wish where member_id = :memberId and product_id = :productId")
+                .param("memberId", memberId)
+                .param("productId", productId)
+                .query(Integer.class)
+                .single();
+
+        return count > 0;
+    }
+
     private static final RowMapper<Wish> wishRowMapper = (rs, rowNum) -> new Wish(
             rs.getLong("id"),
             rs.getLong("member_id"),
-            rs.getLong("product_id")
+            rs.getLong("product_id"),
+            rs.getInt("quantity")
+    );
+
+    private static final RowMapper<WishListResponse> wishListResponseRowMapper = (rs, rowNum) -> new WishListResponse(
+            rs.getLong("wish_id"),
+            rs.getLong("product_id"),
+            rs.getString("product_name"),
+            rs.getString("product_image_url"),
+            rs.getInt("quantity")
     );
 }

--- a/src/main/java/gift/wish/repository/WishRepository.java
+++ b/src/main/java/gift/wish/repository/WishRepository.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Repository
@@ -37,7 +38,7 @@ public class WishRepository {
                 .optional();
     }
 
-    public List<WishListResponse> findByMemberId(Long memberId) {
+    public List<WishListResponse> findWishes(Long memberId) {
         return client.sql("select " +
                         "w.id as wish_id, " +
                         "w.product_id as product_id, " +
@@ -53,20 +54,19 @@ public class WishRepository {
                 .list();
     }
 
-    public boolean updateByIdAndQuantity(Long id, Integer quantity) {
+    public void updateByIdAndQuantity(Long id, Integer quantity) {
         int affected = client.sql("update wish set quantity = :quantity where id = :id")
                 .param("quantity", quantity)
                 .param("id", id)
                 .update();
-
-        return affected > 0;
+        checkAffected(affected);
     }
 
-    public boolean deleteById(Long id) {
+    public void deleteById(Long id) {
         int affected = client.sql("delete from wish where id = :id")
                 .param("id", id)
                 .update();
-        return affected > 0;
+        checkAffected(affected);
     }
 
     public boolean isExist(Long memberId, Long productId){
@@ -94,4 +94,10 @@ public class WishRepository {
             rs.getString("product_image_url"),
             rs.getInt("quantity")
     );
+
+    private void checkAffected(int affected) {
+        if(affected == 0) {
+            throw new NoSuchElementException("해당 위시 항목을 찾을 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,0 +1,66 @@
+package gift.wish.service;
+
+import gift.member.domain.Member;
+import gift.product.domain.Product;
+import gift.product.exception.ProductNotFoundException;
+import gift.product.repository.ProductRepository;
+import gift.product.service.ProductService;
+import gift.wish.domain.Wish;
+import gift.wish.dto.WishListResponse;
+import gift.wish.repository.WishRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+@Service
+@Transactional
+public class WishService {
+
+    private final WishRepository wishRepository;
+    private final ProductRepository productRepository;
+
+    public WishService(WishRepository wishRepository, ProductRepository productRepository) {
+        this.wishRepository = wishRepository;
+        this.productRepository = productRepository;
+    }
+
+    public Wish addWish(Member member, Long productId) {
+        productRepository.findById(productId)
+                .orElseThrow(() -> new ProductNotFoundException("상품을 찾을 수 없습니다. ID: " + productId));
+
+        if (wishRepository.isExist(member.getId(), productId)) {
+            throw new IllegalArgumentException("이미 위시 리스트에 추가된 상품입니다.");
+        }
+
+        return wishRepository.save(member.getId(), productId);
+    }
+
+    public List<WishListResponse> getWishes(Member member) {
+        return wishRepository.findByMemberId(member.getId());
+    }
+
+    public void updateQuantity(Member member, Long wishId, Integer quantity) throws AccessDeniedException {
+        checkValidWishAndMember(member,wishId);
+
+        wishRepository.updateByIdAndQuantity(wishId, quantity);
+    }
+
+    public void deleteWish(Member member, Long wishId) throws AccessDeniedException{
+        checkValidWishAndMember(member,wishId);
+
+        wishRepository.deleteById(wishId);
+    }
+
+    private void checkValidWishAndMember(Member member, Long wishId) throws AccessDeniedException{
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new NoSuchElementException("해당 위시 항목을 찾을 수 없습니다."));
+
+        if (!Objects.equals(wish.getMemberId(), member.getId())){
+            throw new AccessDeniedException("해당 위시 항목을 삭제할 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,20 +1,16 @@
 package gift.wish.service;
 
 import gift.member.domain.Member;
-import gift.product.domain.Product;
 import gift.product.exception.ProductNotFoundException;
 import gift.product.repository.ProductRepository;
-import gift.product.service.ProductService;
 import gift.wish.domain.Wish;
 import gift.wish.dto.WishListResponse;
+import gift.wish.dto.WishResponse;
 import gift.wish.repository.WishRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 
 @Service
 @Transactional
@@ -28,7 +24,7 @@ public class WishService {
         this.productRepository = productRepository;
     }
 
-    public Wish addWish(Member member, Long productId) {
+    public WishResponse addWish(Member member, Long productId) {
         productRepository.findById(productId)
                 .orElseThrow(() -> new ProductNotFoundException("상품을 찾을 수 없습니다. ID: " + productId));
 
@@ -36,31 +32,31 @@ public class WishService {
             throw new IllegalArgumentException("이미 위시 리스트에 추가된 상품입니다.");
         }
 
-        return wishRepository.save(member.getId(), productId);
+        Wish wish = wishRepository.save(member.getId(), productId);
+
+        return new WishResponse(wish.getMemberId(), wish.getProductId(), 1);
     }
 
     public List<WishListResponse> getWishes(Member member) {
-        return wishRepository.findByMemberId(member.getId());
+        return wishRepository.findWishes(member.getId());
     }
 
-    public void updateQuantity(Member member, Long wishId, Integer quantity) throws AccessDeniedException {
+    public void updateQuantity(Member member, Long wishId, Integer quantity){
         checkValidWishAndMember(member,wishId);
 
         wishRepository.updateByIdAndQuantity(wishId, quantity);
     }
 
-    public void deleteWish(Member member, Long wishId) throws AccessDeniedException{
+    public void deleteWish(Member member, Long wishId){
         checkValidWishAndMember(member,wishId);
 
         wishRepository.deleteById(wishId);
     }
 
-    private void checkValidWishAndMember(Member member, Long wishId) throws AccessDeniedException{
+    private void checkValidWishAndMember(Member member, Long wishId){
         Wish wish = wishRepository.findById(wishId)
                 .orElseThrow(() -> new NoSuchElementException("해당 위시 항목을 찾을 수 없습니다."));
 
-        if (!Objects.equals(wish.getMemberId(), member.getId())){
-            throw new AccessDeniedException("해당 위시 항목을 삭제할 권한이 없습니다.");
-        }
+        wish.validateOwner(member.getId());
     }
 }

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,6 +1,7 @@
 package gift.wish.service;
 
 import gift.member.domain.Member;
+import gift.member.dto.MemberTokenRequest;
 import gift.product.exception.ProductNotFoundException;
 import gift.product.repository.ProductRepository;
 import gift.wish.domain.Wish;
@@ -24,39 +25,39 @@ public class WishService {
         this.productRepository = productRepository;
     }
 
-    public WishResponse addWish(Member member, Long productId) {
+    public WishResponse addWish(MemberTokenRequest memberTokenRequest, Long productId) {
         productRepository.findById(productId)
                 .orElseThrow(() -> new ProductNotFoundException("상품을 찾을 수 없습니다. ID: " + productId));
 
-        if (wishRepository.isExist(member.getId(), productId)) {
+        if (wishRepository.isExist(memberTokenRequest.id(), productId)) {
             throw new IllegalArgumentException("이미 위시 리스트에 추가된 상품입니다.");
         }
 
-        Wish wish = wishRepository.save(member.getId(), productId);
+        Wish wish = wishRepository.save(memberTokenRequest.id(), productId);
 
         return new WishResponse(wish.getMemberId(), wish.getProductId(), 1);
     }
 
-    public List<WishListResponse> getWishes(Member member) {
-        return wishRepository.findWishes(member.getId());
+    public List<WishListResponse> getWishes(MemberTokenRequest memberTokenRequest) {
+        return wishRepository.findWishes(memberTokenRequest.id());
     }
 
-    public void updateQuantity(Member member, Long wishId, Integer quantity){
-        checkValidWishAndMember(member,wishId);
+    public void updateQuantity(MemberTokenRequest memberTokenRequest, Long wishId, Integer quantity){
+        checkValidWishAndMember(memberTokenRequest,wishId);
 
         wishRepository.updateByIdAndQuantity(wishId, quantity);
     }
 
-    public void deleteWish(Member member, Long wishId){
-        checkValidWishAndMember(member,wishId);
+    public void deleteWish(MemberTokenRequest memberTokenRequest, Long wishId){
+        checkValidWishAndMember(memberTokenRequest ,wishId);
 
         wishRepository.deleteById(wishId);
     }
 
-    private void checkValidWishAndMember(Member member, Long wishId){
+    private void checkValidWishAndMember(MemberTokenRequest memberTokenRequest, Long wishId){
         Wish wish = wishRepository.findById(wishId)
                 .orElseThrow(() -> new NoSuchElementException("해당 위시 항목을 찾을 수 없습니다."));
 
-        wish.validateOwner(member.getId());
+        wish.validateOwner(memberTokenRequest.id());
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+INSERT INTO product (name, price, image_url) VALUES
+                                                 ('Test1', 30000, 'https://example.com/images/flower.jpg'),
+                                                 ('Test2', 15000, 'https://example.com/images/chocolate.jpg'),
+                                                 ('감사 카드', 5000, 'https://example.com/images/card.jpg'),
+                                                 ('테디베어 인형', 25000, 'https://example.com/images/teddybear.jpg'),
+                                                 ('향초 세트', 20000, 'https://example.com/images/candle.jpg');
+
+-- Insert members
+INSERT INTO member (email, password, role) VALUES
+                                               ('test@example.com', 'l2h5', 'USER'),
+                                               ('admin@example.com', '{noop}admin123', 'ADMIN');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -13,3 +13,13 @@ CREATE TABLE member (
     role VARCHAR(50) NOT NULL,
     PRIMARY KEY (id)
 );
+
+CREATE TABLE wish (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    product_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE CASCADE,
+    UNIQUE (member_id, product_id)
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE wish (
     id BIGINT NOT NULL AUTO_INCREMENT,
     member_id BIGINT NOT NULL,
     product_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
     FOREIGN KEY (product_id) REFERENCES product(id) ON DELETE CASCADE,

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -8,6 +8,9 @@
             <a href="/products" class="nav-link">상품 목록</a>
 
             <th:block th:if="${isLoggedIn}">
+                <a href="/members/mypage" class="nav-link">마이페이지</a>
+            </th:block>
+            <th:block th:if="${isLoggedIn}">
                 <form th:action="@{/members/logout}" method="post" style="display: inline;">
                     <button type="submit" class="nav-link" style="border:none; background:none; cursor:pointer; padding:0; font-size: 1em;">로그아웃</button>
                 </form>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -7,10 +7,14 @@
         <div class="nav-items">
             <a href="/products" class="nav-link">상품 목록</a>
 
-            <form th:action="@{/members/logout}" method="post" style="display: inline;">
-                <button type="submit" class="nav-link" style="border:none; background:none; cursor:pointer; padding:0; font-size: 1em;">로그아웃</button>
-            </form>
-            <a href="/members/login" class="nav-link">로그인</a>
+            <th:block th:if="${isLoggedIn}">
+                <form th:action="@{/members/logout}" method="post" style="display: inline;">
+                    <button type="submit" class="nav-link" style="border:none; background:none; cursor:pointer; padding:0; font-size: 1em;">로그아웃</button>
+                </form>
+            </th:block>
+            <th:block th:unless="${isLoggedIn}">
+                <a href="/members/login" class="nav-link">로그인</a>
+            </th:block>
         </div>
     </nav>
 </header>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -4,13 +4,15 @@
 <header th:fragment="header" class="navbar">
     <a href="/products" class="nav-brand">🎁 GiftShop</a>
     <nav class="nav-items">
+        <div class="nav-items">
+            <a href="/products" class="nav-link">상품 목록</a>
+
+            <form th:action="@{/members/logout}" method="post" style="display: inline;">
+                <button type="submit" class="nav-link" style="border:none; background:none; cursor:pointer; padding:0; font-size: 1em;">로그아웃</button>
+            </form>
+            <a href="/members/login" class="nav-link">로그인</a>
+        </div>
     </nav>
 </header>
-
-<style>
-    .navbar { display: flex; justify-content: space-between; align-items: center; padding: 15px 40px; background-color: #f8f9fa; border-bottom: 1px solid #dee2e6; }
-    .nav-brand { font-size: 1.5em; font-weight: bold; color: #333; }
-    .nav-items { display: flex; align-items: center; gap: 25px; }
-</style>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<header th:fragment="header" class="navbar">
+    <a href="/products" class="nav-brand">🎁 GiftShop</a>
+    <nav class="nav-items">
+    </nav>
+</header>
+
+<style>
+    .navbar { display: flex; justify-content: space-between; align-items: center; padding: 15px 40px; background-color: #f8f9fa; border-bottom: 1px solid #dee2e6; }
+    .nav-brand { font-size: 1.5em; font-weight: bold; color: #333; }
+    .nav-items { display: flex; align-items: center; gap: 25px; }
+</style>
+</body>
+</html>

--- a/src/main/resources/templates/home/home.html
+++ b/src/main/resources/templates/home/home.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GiftShop</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            background: linear-gradient(to bottom, #fff, #fdf6e3);
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .hero {
+            text-align: center;
+            max-width: 600px;
+            padding: 40px 20px;
+            background: #fff;
+            border-radius: 20px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+            animation: fadeIn 1s ease;
+        }
+
+        .hero h1 {
+            font-size: 2.2rem;
+            margin-bottom: 10px;
+            color: #333;
+        }
+
+        .hero p {
+            font-size: 1.1rem;
+            color: #666;
+            margin-bottom: 30px;
+        }
+
+        .hero-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background-color: #ffe812;
+            border: none;
+            border-radius: 30px;
+            font-weight: bold;
+            color: #333;
+            text-decoration: none;
+            transition: background 0.3s;
+        }
+
+        .hero-button:hover {
+            background-color: #ffec3d;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(20px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        @media (max-width: 600px) {
+            .hero h1 {
+                font-size: 1.6rem;
+            }
+            .hero p {
+                font-size: 1rem;
+            }
+        }
+    </style>
+</head>
+<body>
+
+<section class="hero">
+    <h1>🎁 마음을 전하는 선물</h1>
+    <p>소중한 사람에게 따뜻한 마음을 전해보세요.</p>
+    <a href="/members/login" class="hero-button">선물하러 가기</a>
+</section>
+
+</body>
+</html>

--- a/src/main/resources/templates/home/home.html
+++ b/src/main/resources/templates/home/home.html
@@ -1,19 +1,26 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GiftShop</title>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<th:block layout:fragment="title">선물하기</th:block>
+
+<th:block layout:fragment="css">
     <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body {
-            font-family: 'Noto Sans KR', sans-serif;
+        .hero-wrapper {
             background: linear-gradient(to bottom, #fff, #fdf6e3);
-            height: 100vh;
             display: flex;
             align-items: center;
             justify-content: center;
+            padding: 40px 0;
+            min-height: calc(100vh - 75px);
+
+            width: 100vw;
+            position: relative;
+            left: 50%;
+            transform: translateX(-50%);
         }
+        * { box-sizing: border-box; }
 
         .hero {
             text-align: center;
@@ -67,14 +74,15 @@
             }
         }
     </style>
-</head>
-<body>
+</th:block>
 
-<section class="hero">
-    <h1>🎁 마음을 전하는 선물</h1>
-    <p>소중한 사람에게 따뜻한 마음을 전해보세요.</p>
-    <a href="/members/login" class="hero-button">선물하러 가기</a>
-</section>
-
-</body>
+<div layout:fragment="content">
+    <div class="hero-wrapper">
+        <section class="hero">
+            <h1>🎁 마음을 전하는 선물</h1>
+            <p>소중한 사람에게 따뜻한 마음을 전해보세요.</p>
+            <a href="/members/login" class="hero-button">선물하러 가기</a>
+        </section>
+    </div>
+</div>
 </html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultrq.net.nz/thymeleaf/layout">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title layout:title-pattern="$CONTENT_TITLE | GiftShop">GiftShop</title>
+
+    <style>
+        body { font-family: sans-serif; margin: 0; background-color: #fff; }
+        .container { max-width: 1200px; margin: 40px auto; padding: 0 20px; }
+        a { text-decoration: none; color: #007bff; }
+        a:hover { text-decoration: underline; }
+    </style>
+
+    <th:block layout:fragment="css"></th:block>
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}"></div>
+
+<main class="container">
+    <div layout:fragment="content">
+        <p>Page contents</p>
+    </div>
+</main>
+<th:block layout:fragment="script"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -13,6 +13,10 @@
         .container { max-width: 1200px; margin: 40px auto; padding: 0 20px; }
         a { text-decoration: none; color: #007bff; }
         a:hover { text-decoration: underline; }
+
+        .navbar { display: flex; justify-content: space-between; align-items: center; padding: 10px 40px; background-color: #f8f9fa; border-bottom: 1px solid #dee2e6; }
+        .nav-brand { font-size: 1.5em; font-weight: bold; text-decoration: none; color: #333; }
+        .nav-items .nav-link { margin-left: 20px; text-decoration: none; color: #555; font-size: 1em; }
     </style>
 
     <th:block layout:fragment="css"></th:block>

--- a/src/main/resources/templates/members/edit-password-form.html
+++ b/src/main/resources/templates/members/edit-password-form.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<th:block layout:fragment="title">마이페이지</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        .form-container { width: 360px; margin: 60px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h1 { text-align: center; margin-bottom: 20px; }
+        .form-group { margin-bottom: 15px; }
+        label { display: block; margin-bottom: 5px; }
+        input { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+        button { width: 100%; padding: 10px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <div class="form-container">
+        <h1>비밀번호 변경</h1>
+        <form th:action="@{/members/edit}" th:object="${member}" method="post">
+            <div class="form-group">
+                <label for="currentPassword">현재 비밀번호</label>
+                <input type="password" id="currentPassword" th:field="*{password}" required>
+            </div>
+            <div class="form-group">
+                <label for="newPassword">새 비밀번호</label>
+                <input type="password" id="newPassword" th:field="*{newPassword}" required>
+                <p th:if="${#fields.hasErrors('newPassword')}" th:errors="*{newPassword}" style="color:red; font-size: 0.9em;"></p>
+            </div>
+            <button type="submit">변경하기</button>
+            <a href="/members/mypage" style="display: block; text-align: center; margin-top: 10px;">취소</a>
+        </form>
+    </div>
+</div>
+</html>

--- a/src/main/resources/templates/members/edit-password-form.html
+++ b/src/main/resources/templates/members/edit-password-form.html
@@ -25,6 +25,7 @@
                 <input type="password" id="currentPassword" th:field="*{password}" required>
             </div>
             <div class="form-group">
+                <input type="hidden" th:field="*{id}">
                 <label for="newPassword">새 비밀번호</label>
                 <input type="password" id="newPassword" th:field="*{newPassword}" required>
                 <p th:if="${#fields.hasErrors('newPassword')}" th:errors="*{newPassword}" style="color:red; font-size: 0.9em;"></p>

--- a/src/main/resources/templates/members/login.html
+++ b/src/main/resources/templates/members/login.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/src/main/resources/templates/members/login.html
+++ b/src/main/resources/templates/members/login.html
@@ -3,33 +3,35 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/layout}">
 
+<th:block layout:fragment="title">로그인</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        .form-container { max-width: 400px; margin: 40px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h1 { text-align: center; margin-bottom: 20px; }
+        .form-group { margin-bottom: 15px; }
+        label { display: block; margin-bottom: 5px; font-weight: bold; }
+        input[type="email"], input[type="password"] { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+        .btn-primary { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
+        .message { text-align: center; margin-top: 15px; }
+    </style>
+</th:block>
+
 <div layout:fragment="content">
-    <head>
-        <title>로그인</title>
-        <style>
-            .form-container { max-width: 400px; margin: 40px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-            h1 { text-align: center; margin-bottom: 20px; }
-            .form-group { margin-bottom: 15px; }
-            label { display: block; margin-bottom: 5px; font-weight: bold; }
-            input[type="email"], input[type="password"] { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
-            .btn-primary { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
-            .message { text-align: center; margin-top: 15px; }
-        </style>
-        <div class="form-container">
-            <h1>로그인</h1>
-            <form th:action="@{/members/login}" th:object="${member}" method="post">
-                <div class="form-group">
-                    <label for="email">이메일</label>
-                    <input type="email" id="email" th:field="*{email}" required>
-                </div>
-                <div class="form-group">
-                    <label for="password">비밀번호</label>
-                    <input type="password" id="password" th:field="*{password}" required>
-                </div>
-                <button type="submit" class="btn-primary">로그인</button>
-                <p class="message">계정이 없으신가요? <a href="/members/register">회원가입</a></p>
-            </form>
-        </div>
-    </head>
+    <div class="form-container">
+        <h1>로그인</h1>
+        <form th:action="@{/members/login}" th:object="${member}" method="post">
+            <div class="form-group">
+                <label for="email">이메일</label>
+                <input type="email" id="email" th:field="*{email}" required>
+            </div>
+            <div class="form-group">
+                <label for="password">비밀번호</label>
+                <input type="password" id="password" th:field="*{password}" required>
+            </div>
+            <button type="submit" class="btn-primary">로그인</button>
+            <p class="message">계정이 없으신가요? <a href="/members/register">회원가입</a></p>
+        </form>
+    </div>
 </div>
-<html>
+</html>

--- a/src/main/resources/templates/members/mypage.html
+++ b/src/main/resources/templates/members/mypage.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<th:block layout:fragment="title">마이페이지</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        .my-container { width: 400px; margin: 60px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .info-group { margin-bottom: 20px; font-size: 1.1em; }
+        .btn { display: block; width: 100%; text-align: center; padding: 10px; text-decoration: none; border-radius: 4px; margin-bottom: 10px; color: white; border: none; font-size: 1em; cursor: pointer; }
+        .btn-primary { background-color: #007bff; }
+        .btn-danger { background-color: #dc3545; }
+        .form-group { margin-top: 20px; }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <div class="my-container">
+        <h1>마이페이지</h1>
+        <div class="info-group">
+            <strong>이메일:</strong> <span th:text="${member.email}">user@example.com</span>
+        </div>
+        <a href="/members/edit" class="btn btn-primary">비밀번호 변경</a>
+        <hr>
+        <form th:action="@{/members/delete}" method="post" onsubmit="return confirm('정말로 탈퇴하시겠습니까? 모든 정보가 삭제됩니다.');">
+            <div class="form-group">
+                <label for="password">비밀번호 확인</label>
+                <input type="password" id="password" name="password" placeholder="회원 탈퇴를 위해 비밀번호를 입력하세요" required style="width: 100%; padding: 10px; box-sizing: border-box; margin-top: 5px;">
+            </div>
+            <button type="submit" class="btn btn-danger" style="margin-top: 10px;">회원 탈퇴</button>
+        </form>
+    </div>
+</div>
+</html>

--- a/src/main/resources/templates/members/register.html
+++ b/src/main/resources/templates/members/register.html
@@ -3,19 +3,20 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/layout}">
 
+<th:block layout:fragment="title">회원가입</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        .form-container { max-width: 400px; margin: 40px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h1 { text-align: center; margin-bottom: 20px; }
+        .form-group { margin-bottom: 15px; }
+        label { display: block; margin-bottom: 5px; font-weight: bold; }
+        input[type="email"], input[type="password"] { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+        .btn-primary { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
+        .message { text-align: center; margin-top: 15px; }
+    </style>
+</th:block>
 <div layout:fragment="content">
-    <head>
-        <title>회원가입</title>
-        <style>
-            .form-container { max-width: 400px; margin: 40px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-            h1 { text-align: center; margin-bottom: 20px; }
-            .form-group { margin-bottom: 15px; }
-            label { display: block; margin-bottom: 5px; font-weight: bold; }
-            input[type="email"], input[type="password"] { width: 100%; padding: 10px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
-            .btn-primary { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
-            .message { text-align: center; margin-top: 15px; }
-        </style>
-    </head>
     <div class="form-container">
         <h1>회원가입</h1>
         <form th:action="@{/members/register}" th:object="${member}" method="post">

--- a/src/main/resources/templates/members/register.html
+++ b/src/main/resources/templates/members/register.html
@@ -5,7 +5,7 @@
 
 <div layout:fragment="content">
     <head>
-        <title>로그인</title>
+        <title>회원가입</title>
         <style>
             .form-container { max-width: 400px; margin: 40px auto; padding: 30px; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
             h1 { text-align: center; margin-bottom: 20px; }
@@ -15,21 +15,21 @@
             .btn-primary { width: 100%; padding: 12px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 1em; }
             .message { text-align: center; margin-top: 15px; }
         </style>
-        <div class="form-container">
-            <h1>로그인</h1>
-            <form th:action="@{/members/login}" th:object="${member}" method="post">
-                <div class="form-group">
-                    <label for="email">이메일</label>
-                    <input type="email" id="email" th:field="*{email}" required>
-                </div>
-                <div class="form-group">
-                    <label for="password">비밀번호</label>
-                    <input type="password" id="password" th:field="*{password}" required>
-                </div>
-                <button type="submit" class="btn-primary">로그인</button>
-                <p class="message">계정이 없으신가요? <a href="/members/register">회원가입</a></p>
-            </form>
-        </div>
     </head>
+    <div class="form-container">
+        <h1>회원가입</h1>
+        <form th:action="@{/members/register}" th:object="${member}" method="post">
+            <div class="form-group">
+                <label for="email">이메일</label>
+                <input type="email" id="email" th:field="*{email}" required>
+            </div>
+            <div class="form-group">
+                <label for="password">비밀번호</label>
+                <input type="password" id="password" th:field="*{password}" required>
+            </div>
+            <button type="submit" class="btn-primary">회원가입</button>
+            <p class="message">계정이 있으신가요? <a href="/members/login">로그인</a></p>
+        </form>
+    </div>
 </div>
-<html>
+</html>

--- a/src/main/resources/templates/products/products.html
+++ b/src/main/resources/templates/products/products.html
@@ -22,7 +22,7 @@
             <th>상품 이미지</th>
             <th>상품명</th>
             <th>가격</th>
-            <!--위시 리스트 추가 필요-->
+            <th>위시 리스트</th>
         </tr>
         </thead>
         <tbody>
@@ -30,6 +30,12 @@
             <td><img th:src="${product.imageUrl}" th:alt="${product.name}" width="100"></td>
             <td th:text="${product.name}">상품명</td>
             <td th:text="${product.price} + '원'">가격</td>
+            <td>
+                <form th:action="@{/wishes/add}" method="post">
+                    <input type="hidden" name="productId" th:value="${product.id}">
+                    <button type="submit" class="wish-btn">❤️ 추가</button>
+                </form>
+            </td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/products/products.html
+++ b/src/main/resources/templates/products/products.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<th:block layout:fragment="title">상품 목록</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ddd; padding: 12px; text-align: left; vertical-align: middle; }
+        th { background-color: #f2f2f2; }
+        .wish-btn { padding: 5px 10px; background-color: #ffc107; color: black; border: none; cursor: pointer; border-radius: 4px; }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <h1>전체 상품 목록</h1>
+    <table>
+        <thead>
+        <tr>
+            <th>상품 이미지</th>
+            <th>상품명</th>
+            <th>가격</th>
+            <!--위시 리스트 추가 필요-->
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="product : ${products}">
+            <td><img th:src="${product.imageUrl}" th:alt="${product.name}" width="100"></td>
+            <td th:text="${product.name}">상품명</td>
+            <td th:text="${product.price} + '원'">가격</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</html>

--- a/src/main/resources/templates/wishes/wishes.html
+++ b/src/main/resources/templates/wishes/wishes.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<th:block layout:fragment="title">위시 리스트</th:block>
+
+<th:block layout:fragment="css">
+    <style>
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ddd; padding: 12px; text-align: left; vertical-align: middle; }
+        th { background-color: #f2f2f2; }
+        .delete-btn { padding: 5px 10px; background-color: #dc3545; color: white; border: none; cursor: pointer; border-radius: 4px; }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+    <div class="container">
+        <h1>나의 위시 리스트</h1>
+        <table>
+            <thead>
+            <tr>
+                <th>상품 이미지</th>
+                <th>상품명</th>
+                <th>가격</th>
+                <th>수량</th>
+                <th>삭제</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:if="${wishes.isEmpty()}">
+                <td colspan="5" style="text-align: center;">위시 리스트에 담긴 상품이 없습니다.</td>
+            </tr>
+            <tr th:each="wish : ${wishes}">
+                <td><img th:src="${wish.productImageUrl}" th:alt="${wish.productName}" width="100"></td>
+                <td th:text="${wish.productName}">상품명</td>
+                <td th:text="${wish.productPrice}">상품 가격</td>
+                <td>
+                    <form th:action="@{/wishes/update}" method="post" style="display: flex; align-items: center; gap: 8px;">
+                        <input type="hidden" name="wishId" th:value="${wish.wishId}"/>
+                        <input type="number" name="quantity" th:value="${wish.quantity}" class="form-control" style="width: 60px; text-align: center;" min="1"/>
+                        <button type="submit" class="btn btn-sm btn-primary">수정</button>
+                    </form>
+                </td>
+                <td>
+                    <form th:action="@{'wishes/delete/' + ${wish.wishId}}" method="post">
+                        <button type="submit" class="delete-btn" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+
+</div>
+</html>

--- a/src/main/resources/templates/wishes/wishes.html
+++ b/src/main/resources/templates/wishes/wishes.html
@@ -36,14 +36,13 @@
                 <td th:text="${wish.productName}">상품명</td>
                 <td th:text="${wish.productPrice}">상품 가격</td>
                 <td>
-                    <form th:action="@{/wishes/update}" method="post" style="display: flex; align-items: center; gap: 8px;">
-                        <input type="hidden" name="wishId" th:value="${wish.wishId}"/>
+                    <form th:action="@{'/wishes/update/' + ${wish.wishId}}" method="post" style="display: flex; align-items: center; gap: 8px;">
                         <input type="number" name="quantity" th:value="${wish.quantity}" class="form-control" style="width: 60px; text-align: center;" min="1"/>
                         <button type="submit" class="btn btn-sm btn-primary">수정</button>
                     </form>
                 </td>
                 <td>
-                    <form th:action="@{'wishes/delete/' + ${wish.wishId}}" method="post">
+                    <form th:action="@{'/wishes/delete/' + ${wish.wishId}}" method="post">
                         <button type="submit" class="delete-btn" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</button>
                     </form>
                 </td>

--- a/src/test/java/gift/common/ControllerTestTemplate.java
+++ b/src/test/java/gift/common/ControllerTestTemplate.java
@@ -1,0 +1,64 @@
+package gift.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ControllerTestTemplate {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected ResultActions getWithoutToken(String url) throws Exception {
+        return mockMvc.perform(get(url));
+    }
+
+    protected ResultActions getWithToken(String url, String token) throws Exception {
+        return mockMvc.perform(get(url)
+                .header("Authorization", "Bearer " + token)
+                .accept(MediaType.APPLICATION_JSON));
+    }
+
+    protected ResultActions postWithToken(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(body)));
+    }
+
+    protected ResultActions postWithoutToken(String url, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(body)));
+    }
+
+    protected ResultActions putWithToken(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(put(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(body)));
+    }
+
+    protected ResultActions deleteWithToken(String url, String token) throws Exception {
+        return mockMvc.perform(delete(url)
+                .header("Authorization", "Bearer " + token));
+    }
+
+
+    private String toJson(Object data) throws Exception {
+        return objectMapper.writeValueAsString(data);
+    }
+}

--- a/src/test/java/gift/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/gift/member/controller/MemberApiControllerTest.java
@@ -1,6 +1,5 @@
 package gift.member.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.common.ControllerTestTemplate;
 import gift.member.dto.MemberLoginRequest;
 import gift.member.dto.MemberRegisterRequest;
@@ -56,21 +55,21 @@ public class MemberApiControllerTest extends ControllerTestTemplate {
         String jsonResponse = loginResult.getResponse().getContentAsString();
         String token = objectMapper.readValue(jsonResponse, MemberTokenResponse.class).token();
 
-        getWithToken("/admin/products", token)
+        getWithToken("/api/products", token)
                 .andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("토큰 없이 product list 조회 - 401")
     void accessResourceWithoutToken() throws Exception{
-        getWithoutToken("/admin/products")
+        getWithoutToken("/api/products")
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @DisplayName("유효하지 않은 토큰으로 product list 조회 - 401")
     void accessResourceWithNotValidToken() throws Exception{
-        getWithToken("/admin/products", "testToken")
+        getWithToken("/api/products", "testToken")
                 .andExpect(status().isUnauthorized());
     }
 

--- a/src/test/java/gift/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/gift/member/controller/MemberApiControllerTest.java
@@ -44,7 +44,7 @@ public class MemberApiControllerTest extends ControllerTestTemplate {
     @DisplayName("로그인 후 product list 조회 - 200")
     void loginAndAccessResource() throws Exception {
 
-        postWithoutToken("/api/members/register", getRegisterRequest())
+        postWithoutToken("/api/members/register/admin", getRegisterRequest())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").isString());
 
@@ -55,7 +55,7 @@ public class MemberApiControllerTest extends ControllerTestTemplate {
         String jsonResponse = loginResult.getResponse().getContentAsString();
         String token = objectMapper.readValue(jsonResponse, MemberTokenResponse.class).token();
 
-        getWithToken("/api/products", token)
+        getWithToken("/api/admin/products", token)
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/gift/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/gift/member/controller/MemberApiControllerTest.java
@@ -1,36 +1,24 @@
 package gift.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.common.ControllerTestTemplate;
 import gift.member.dto.MemberLoginRequest;
 import gift.member.dto.MemberRegisterRequest;
 import gift.member.dto.MemberTokenResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-public class MemberApiControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
+public class MemberApiControllerTest extends ControllerTestTemplate {
     private String testEmail;
     private String testPassword;
 
@@ -43,19 +31,12 @@ public class MemberApiControllerTest {
     @Test
     @DisplayName("회원가입 후 로그인 - 200")
     void registerAndLogin() throws Exception{
-        MemberRegisterRequest registerRequest = new MemberRegisterRequest(testEmail, testPassword);
 
-        mockMvc.perform(post("/api/members/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(registerRequest)))
+        postWithoutToken("/api/members/register", getRegisterRequest())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").isString());
 
-        MemberLoginRequest loginRequest = new MemberLoginRequest(testEmail, testPassword);
-
-        mockMvc.perform(post("/api/members/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+        postWithoutToken("/api/members/login", getRegisterRequest())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").isString());
     }
@@ -63,42 +44,41 @@ public class MemberApiControllerTest {
     @Test
     @DisplayName("로그인 후 product list 조회 - 200")
     void loginAndAccessResource() throws Exception {
-        MemberRegisterRequest registerRequest = new MemberRegisterRequest(testEmail, testPassword);
 
-        mockMvc.perform(post("/api/members/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(registerRequest)))
+        postWithoutToken("/api/members/register", getRegisterRequest())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").isString());
 
-        MemberLoginRequest loginRequest = new MemberLoginRequest(testEmail, testPassword);
-
-        MvcResult loginResult = mockMvc.perform(post("/api/members/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+        MvcResult loginResult = postWithoutToken("/api/members/login", getRegisterRequest())
                 .andExpect(status().isOk())
                 .andReturn();
 
         String jsonResponse = loginResult.getResponse().getContentAsString();
         String token = objectMapper.readValue(jsonResponse, MemberTokenResponse.class).token();
 
-        mockMvc.perform(get("/api/products")
-                .header("Authorization", "Bearer " + token))
+        getWithToken("/admin/products", token)
                 .andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("토큰 없이 product list 조회 - 401")
     void accessResourceWithoutToken() throws Exception{
-        mockMvc.perform(get("/admin/products"))
+        getWithoutToken("/admin/products")
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @DisplayName("유효하지 않은 토큰으로 product list 조회 - 401")
     void accessResourceWithNotValidToken() throws Exception{
-        mockMvc.perform(get("/admin/products")
-                .header("Authentication", "Bearer test"))
+        getWithToken("/admin/products", "testToken")
                 .andExpect(status().isUnauthorized());
+    }
+
+    MemberRegisterRequest getRegisterRequest(){
+        return new MemberRegisterRequest(testEmail, testPassword);
+    }
+
+    MemberLoginRequest getLoginRequest(){
+        return new MemberLoginRequest(testEmail, testPassword);
     }
 }

--- a/src/test/java/gift/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/gift/member/controller/MemberApiControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 public class MemberApiControllerTest extends ControllerTestTemplate {

--- a/src/test/java/gift/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/gift/product/controller/ProductApiControllerTest.java
@@ -39,7 +39,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     void setUp() {
         MemberRegisterRequest request = new MemberRegisterRequest("test@gmail.com", "12345678");
 
-        adminToken = memberService.register(request).token();
+        adminToken = memberService.registerAdmin(request).token();
 
         product1 = productService.saveProduct(getProductRequest("Test1", 1000, "Test1.jpg"));
         product2 = productService.saveProduct(getProductRequest("Test2", 1200, "Test2.jpg"));
@@ -48,7 +48,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     @Test
     @DisplayName("상품 등록 테스트 - 201")
     void addProduct() throws Exception {
-        postWithToken("/api/products", adminToken, getProductRequest("new", 1500, "new.png"))
+        postWithToken("/api/admin/products", adminToken, getProductRequest("new", 1500, "new.png"))
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
@@ -56,7 +56,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     @Test
     @DisplayName("전체 상품 조회 테스트 - 200")
     void getProducts() throws Exception {
-        getWithToken("/api/products", adminToken)
+        getWithToken("/api/admin/products", adminToken)
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].name", is("Test1")))
@@ -69,7 +69,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     void getProductById() throws Exception{
         Long productId = product1.getId();
 
-        getWithToken("/api/products/" + productId, adminToken)
+        getWithToken("/api/admin/products/" + productId, adminToken)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(productId.intValue())))
                 .andDo(print());
@@ -80,7 +80,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     void getProductNotFound() throws Exception{
         Long notFoundId = 999999L;
 
-        getWithToken("/api/products/" + notFoundId, adminToken)
+        getWithToken("/api/admin/products/" + notFoundId, adminToken)
                 .andExpect(status().isNotFound())
                 .andDo(print());
     }
@@ -90,11 +90,11 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     void updateProduct() throws Exception{
         Long productId = product1.getId();
 
-        putWithToken("/api/products/" + productId, adminToken, getProductRequest("수정된 이름", 12000, "updated"))
+        putWithToken("/api/admin/products/" + productId, adminToken, getProductRequest("수정된 이름", 12000, "updated"))
                 .andExpect(status().isNoContent())
                 .andDo(print());
 
-        getWithToken("/api/products/" + productId, adminToken)
+        getWithToken("/api/admin/products/" + productId, adminToken)
                 .andExpect(jsonPath("$.name", is("수정된 이름")))
                 .andExpect(jsonPath("$.price", is(12000)));
     }
@@ -104,11 +104,11 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     void deleteProduct() throws Exception {
         Long productId = product1.getId();
 
-        deleteWithToken("/api/products/" + productId, adminToken)
+        deleteWithToken("/api/admin/products/" + productId, adminToken)
                 .andExpect(status().isNoContent())
                 .andDo(print());
 
-        getWithToken("/api/products/" + productId, adminToken)
+        getWithToken("/api/admin/products/" + productId, adminToken)
                 .andExpect(status().isNotFound());
     }
 
@@ -116,7 +116,7 @@ public class ProductApiControllerTest extends ControllerTestTemplate {
     @DisplayName("상품 등록 실패 - 유효하지 않은 상품명(카카오) - 400")
     void addProduct_fail() throws Exception {
 
-        postWithToken("/api/products", adminToken, getProductRequest("카카오 인형", 15000, "a.jpg"))
+        postWithToken("/api/admin/products", adminToken, getProductRequest("카카오 인형", 15000, "a.jpg"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.name").exists())
                 .andDo(print());

--- a/src/test/java/gift/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/gift/product/controller/ProductApiControllerTest.java
@@ -1,6 +1,5 @@
 package gift.product.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gift.common.ControllerTestTemplate;
 import gift.member.dto.MemberRegisterRequest;
 import gift.member.service.MemberService;
@@ -14,12 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/src/test/java/gift/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/gift/product/controller/ProductApiControllerTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
 @DisplayName("ProductApiController 테스트")


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?

회원 관리 위시 리스트 만들기

# 어떻게 해결했나요?

- [x] Member register, login 테스트 코드 작성
- [x] 테스트 코드 메소드 추출, 불필요한 코드 제거
- [x] 회원 login, register 페이지 구현
- [x] cookie 기반 토큰 인터셉터 처리 로직 구현
- [x] 위시 리스트 domain, repository 설계
- [x] 위시 리스트 service, controller 설계
- [x] 위시 리스트 페이지 구현
- [x] 상품 관리 관리자 페이지 접근 권한 검증
- [x] 회원 수정, 삭제에 필요한 service, repository 추가 구현
- [x] 회원 수정, 삭제 페이지 구현

# 어떤 부분에 집중하여 리뷰해야 할까요?

- JWT 토큰 인증을 api 요청은 header를 통해, 웹 기반 요청은 Cookie 기반으로 처리했습니다.
- admin 권한을 가진 사용자만 상품 관리 페이지에 접속가능하도록 인터셉터를 별도로 만들어서 처리했습니다.
- Thymeleaf layout을 최대한 적용해서 프론트 페이지 재사용성을 높였습니다.

- 비밀번호 암호화의 경우 적용하고 싶었는데, 다른 기능 구현에 시간을 너무 많이 써서 이번 단계에서 처리하지는 못했습니다.
- 관리자 계정 생성하는 페이지가 별도로 있어야 할 것 같은데, 이를 일반 사용자가 접근가능한 경로로 만드는 것은 적절하지 않은 것 같습니다. DB data.sql에서 관리자를 미리 생성하는 것이 최선인지 잘 모르겠습니다.
