### PR TITLE
경북대 BE_김도현 Step3 - 위시 리스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,18 @@
 - ``jwt web token`` 사용
 - 도메인에서 회원 인증 로직 구현(isEuqalPassword())
 - 응용 서비스에서 토큰 생성 구현
+
+## Step 3 : 위시 리스트
+### 요구사항 분석
+- 위시 리스트 API 구성
+  - 위시 리스트에 상품 추가
+  - 위시 리스트에 등록된 상품 조회
+  - 위시 리스트에 담긴 상품 삭제
+### 구현 방향
+| 기능                | Method | URL                     | Request Information                                               | Response Body            | 상태코드   |
+|-------------------|--------|-------------------------|-------------------------------------------------------------------|--------------------------|--------|
+| 위시 리스트에 상품 추가     | POST   | /api/wishes             | Header: Authorization: Bearer <JWT> <br/> Body: { "productId": n } | 없음                       | 201 |
+| 위시 리스트에 등록된 상품 조회 | GET    | /api/wishes             | Header: Authorization: Bearer <JWT>                               | List<ProductResponseDto> | 200    |
+| 위시 리스트에 담긴 상품 삭제  | DELETE | /api/wishes/{productId} | - Header: Authorization: Bearer <JWT> <br/> PathVariable: productId   | 없음                       | 204    |
+- `@LoginUser` 어노테이션 & `HandlerMethodArgumentResolver` 구현
+  - 컨트롤러 메서드 파라미터에 로그인 유저 정보를 직접 주입

--- a/src/main/java/gift/configuration/WebConfiguration.java
+++ b/src/main/java/gift/configuration/WebConfiguration.java
@@ -1,0 +1,22 @@
+package gift.configuration;
+
+import gift.security.LoginUserArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+  private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+  public WebConfiguration(LoginUserArgumentResolver loginUserArgumentResolver) {
+    this.loginUserArgumentResolver = loginUserArgumentResolver;
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+    argumentResolvers.add(loginUserArgumentResolver);
+  }
+}

--- a/src/main/java/gift/exception/ErrorCode.java
+++ b/src/main/java/gift/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
   INVALID_PASSWORD("INVALID_PASSWORD","회원가입 비밀번호 형식이 다릅니다.",HttpStatus.BAD_REQUEST),
   INVALID_LOGIN("INVALID_LOGIN", "이메일 또는 비밀번호가 일치하지 않습니다.",HttpStatus.FORBIDDEN),
   USER_NOT_FOUND("USER_NOT_FOUND","존재하지 않는 사용자입니다.",HttpStatus.NOT_FOUND),
-  PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND","존재하지 않는 상품입니다.",HttpStatus.NOT_FOUND);
+  PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND","존재하지 않는 상품입니다.",HttpStatus.NOT_FOUND),
+
+  INVALID_JWT("INVALID_JWT","유효하지 않은 토큰입니다.",HttpStatus.UNAUTHORIZED);
 
   private final String code;
   private final String message;

--- a/src/main/java/gift/exception/ErrorCode.java
+++ b/src/main/java/gift/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
   INVALID_LOGIN("INVALID_LOGIN", "이메일 또는 비밀번호가 일치하지 않습니다.",HttpStatus.FORBIDDEN),
   USER_NOT_FOUND("USER_NOT_FOUND","존재하지 않는 사용자입니다.",HttpStatus.NOT_FOUND),
   PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND","존재하지 않는 상품입니다.",HttpStatus.NOT_FOUND),
+  WISH_NOT_FOUND("WISH_NOT_FOUND","위시리스트가 존재하지 않습니다.",HttpStatus.NOT_FOUND),
 
   INVALID_JWT("INVALID_JWT","유효하지 않은 토큰입니다.",HttpStatus.UNAUTHORIZED);
 

--- a/src/main/java/gift/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/gift/exception/ExceptionHandlerAdvice.java
@@ -36,4 +36,12 @@ public class ExceptionHandlerAdvice {
     return ResponseEntity.status(ex.getErrorCode().getStatus()).body(errorResponse);
   }
 
+  @ExceptionHandler(UnAuthorizationException.class)
+  public ResponseEntity<ErrorResponse> handleUnAuthorizationException(UnAuthorizationException ex) {
+
+    ErrorResponse errorResponse = ErrorResponse.of(ex.getErrorCode());
+
+    return ResponseEntity.status(ex.getErrorCode().getStatus()).body(errorResponse);
+  }
+
 }

--- a/src/main/java/gift/exception/UnAuthorizationException.java
+++ b/src/main/java/gift/exception/UnAuthorizationException.java
@@ -1,0 +1,16 @@
+package gift.exception;
+
+public class UnAuthorizationException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public UnAuthorizationException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+}

--- a/src/main/java/gift/exception/WishNotFoundException.java
+++ b/src/main/java/gift/exception/WishNotFoundException.java
@@ -1,0 +1,8 @@
+package gift.exception;
+
+public class WishNotFoundException extends BusinessException{
+  public WishNotFoundException() {
+    super(ErrorCode.WISH_NOT_FOUND);
+  }
+
+}

--- a/src/main/java/gift/security/AdminInterceptor.java
+++ b/src/main/java/gift/security/AdminInterceptor.java
@@ -31,7 +31,7 @@ public class AdminInterceptor implements HandlerInterceptor {
       return true;
     }
 
-    res.setStatus(HttpStatus.UNAUTHORIZED.value());
+    res.setStatus(HttpStatus.FORBIDDEN.value());
     return false;
   }
 

--- a/src/main/java/gift/security/LoginUser.java
+++ b/src/main/java/gift/security/LoginUser.java
@@ -1,0 +1,11 @@
+package gift.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/gift/security/LoginUserArgumentResolver.java
+++ b/src/main/java/gift/security/LoginUserArgumentResolver.java
@@ -1,0 +1,45 @@
+package gift.security;
+
+import gift.exception.ErrorCode;
+import gift.exception.UnAuthorizationException;
+import gift.user.service.UserService;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final UserService userService;
+
+  public LoginUserArgumentResolver(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(LoginUser.class);
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) throws Exception {
+
+    var authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+    String token = authorization.substring(7);
+
+    if (token == null || token.isBlank()) {
+      throw new UnAuthorizationException(ErrorCode.INVALID_JWT);
+    }
+
+    return userService.findUserByToken(token);
+  }
+
+
+}

--- a/src/main/java/gift/security/LoginUserArgumentResolver.java
+++ b/src/main/java/gift/security/LoginUserArgumentResolver.java
@@ -32,9 +32,14 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
       WebDataBinderFactory binderFactory) throws Exception {
 
     var authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (authorization == null || authorization.isBlank() || !authorization.startsWith("Bearer ")) {
+      throw new UnAuthorizationException(ErrorCode.INVALID_JWT);
+    }
+
     String token = authorization.substring(7);
 
-    if (token == null || token.isBlank()) {
+    if (token.isBlank()) {
       throw new UnAuthorizationException(ErrorCode.INVALID_JWT);
     }
 

--- a/src/main/java/gift/user/JwtTokenProvider.java
+++ b/src/main/java/gift/user/JwtTokenProvider.java
@@ -71,4 +71,19 @@ public String getRole(String token) throws Exception {
   } catch (Exception e) {
     throw new Exception("토큰에서 role을 가져올 수 없습니다", e);
   }
-}}
+}
+
+  public String getEmail(String token) throws Exception {
+    try {
+      Claims claims = jwtParser.parseSignedClaims(token).getPayload();
+      return claims.get("email", String.class);
+    } catch (JwtException e) {
+      throw new Exception("유효하지 않은 토큰입니다", e);
+    } catch (IllegalArgumentException e) {
+      throw new Exception("토큰이 null이거나 빈 문자열입니다", e);
+    } catch (Exception e) {
+      throw new Exception("토큰에서 role을 가져올 수 없습니다", e);
+    }
+  }
+
+}

--- a/src/main/java/gift/user/service/UserService.java
+++ b/src/main/java/gift/user/service/UserService.java
@@ -1,5 +1,7 @@
 package gift.user.service;
 
+import gift.exception.ErrorCode;
+import gift.exception.UnAuthorizationException;
 import gift.security.PasswordEncoder;
 import gift.user.JwtTokenProvider;
 import gift.user.dto.LoginRequestDto;
@@ -102,6 +104,21 @@ public class UserService {
   public void deleteUser(Long userId) {
     findByIdOrFail(userId);
     userDao.deleteById(userId);
+  }
+
+  public User findUserByToken(String token) {
+    try {
+      String email = jwtTokenProvider.getEmail(token);
+      User user = userDao.findByEmail(email);
+
+      if (user == null) {
+        throw new UserNotFoundException();
+      }
+
+      return user;
+    } catch (Exception e) {
+      throw new UnAuthorizationException(ErrorCode.INVALID_JWT);
+    }
   }
 
 

--- a/src/main/java/gift/wish/controller/WishRestController.java
+++ b/src/main/java/gift/wish/controller/WishRestController.java
@@ -1,13 +1,16 @@
 package gift.wish.controller;
 
+import gift.product.dto.ProductResponseDto;
 import gift.security.LoginUser;
 import gift.user.domain.User;
 import gift.wish.dto.WishResponseDto;
 import gift.wish.service.WishService;
 import gift.wish.dto.WishRequestDto;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +33,12 @@ public class WishRestController {
     return ResponseEntity.status(HttpStatus.CREATED).body(wishResponseDto);
   }
 
+  @GetMapping("/api/wishes")
+  public ResponseEntity<List<ProductResponseDto>> getWishes(
+      @LoginUser User user
+  ) {
+    List<ProductResponseDto> products = wishService.getWishes(user.getId());
+    return ResponseEntity.ok(products);
+  }
 
 }

--- a/src/main/java/gift/wish/controller/WishRestController.java
+++ b/src/main/java/gift/wish/controller/WishRestController.java
@@ -10,7 +10,9 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,6 +41,13 @@ public class WishRestController {
   ) {
     List<ProductResponseDto> products = wishService.getWishes(user.getId());
     return ResponseEntity.ok(products);
+  }
+
+  @DeleteMapping("/api/wishes/{productId}")
+  public ResponseEntity<Void> deleteWish(@PathVariable Long productId,
+      @LoginUser User user) {
+    wishService.deleteWish(user.getId(), productId);
+    return ResponseEntity.noContent().build();
   }
 
 }

--- a/src/main/java/gift/wish/controller/WishRestController.java
+++ b/src/main/java/gift/wish/controller/WishRestController.java
@@ -1,0 +1,34 @@
+package gift.wish.controller;
+
+import gift.security.LoginUser;
+import gift.user.domain.User;
+import gift.wish.dto.WishResponseDto;
+import gift.wish.service.WishService;
+import gift.wish.dto.WishRequestDto;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WishRestController {
+
+  private final WishService wishService;
+
+  public WishRestController(WishService wishService) {
+    this.wishService = wishService;
+  }
+
+  @PostMapping("/api/wishes")
+  public ResponseEntity<WishResponseDto> createWish(
+      @Valid @RequestBody WishRequestDto wishRequestDto,
+      @LoginUser User user
+  ) {
+    WishResponseDto wishResponseDto = wishService.createWish(user.getId(), wishRequestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(wishResponseDto);
+  }
+
+
+}

--- a/src/main/java/gift/wish/dao/WishDao.java
+++ b/src/main/java/gift/wish/dao/WishDao.java
@@ -1,6 +1,9 @@
 package gift.wish.dao;
 
+import gift.product.dto.ProductResponseDto;
+import gift.user.domain.Role;
 import gift.wish.dto.WishResponseDto;
+import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -33,5 +36,14 @@ public class WishDao {
             rs.getLong("productId")
         ))
         .single();
+  }
+
+  public List<Long> findProductIdsByMemberId(Long memberId) {
+    String sql = "SELECT productId FROM wishes WHERE memberId = ?";
+
+    return jdbcClient.sql(sql)
+        .param(memberId)
+        .query(Long.class)
+        .list();
   }
 }

--- a/src/main/java/gift/wish/dao/WishDao.java
+++ b/src/main/java/gift/wish/dao/WishDao.java
@@ -1,0 +1,37 @@
+package gift.wish.dao;
+
+import gift.wish.dto.WishResponseDto;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class WishDao {
+  private final JdbcClient jdbcClient;
+
+  public WishDao(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public WishResponseDto createWish(Long memberId, Long productId) {
+    String sql = "INSERT INTO wishes (memberId, productId) VALUES (?, ?)";
+
+    jdbcClient.sql(sql)
+        .param(memberId)
+        .param(productId)
+        .update();
+
+    String selectSql = "SELECT wishId, memberId, productId " +
+        "FROM wishes WHERE memberId = ? AND productId = ?";
+
+    return jdbcClient.sql(selectSql)
+        .param(memberId)
+        .param(productId)
+        .query((rs, rowNum) -> new WishResponseDto(
+            rs.getLong("wishId"),
+            rs.getLong("memberId"),
+            rs.getLong("productId")
+        ))
+        .single();
+  }
+}

--- a/src/main/java/gift/wish/dao/WishDao.java
+++ b/src/main/java/gift/wish/dao/WishDao.java
@@ -1,5 +1,7 @@
 package gift.wish.dao;
 
+import gift.exception.BusinessException;
+import gift.exception.ErrorCode;
 import gift.product.dto.ProductResponseDto;
 import gift.user.domain.Role;
 import gift.wish.dto.WishResponseDto;
@@ -45,5 +47,19 @@ public class WishDao {
         .param(memberId)
         .query(Long.class)
         .list();
+  }
+
+  public void deleteWish(Long memberId, Long productId) {
+    String sql = "DELETE FROM wishes WHERE memberId = ? AND productId = ?";
+
+    int deletedRow = jdbcClient.sql(sql)
+        .param(memberId)
+        .param(productId)
+        .update();
+
+    if (deletedRow == 0) {
+      throw new BusinessException(ErrorCode.WISH_NOT_FOUND);
+    }
+
   }
 }

--- a/src/main/java/gift/wish/dao/WishDao.java
+++ b/src/main/java/gift/wish/dao/WishDao.java
@@ -40,12 +40,29 @@ public class WishDao {
         .single();
   }
 
-  public List<Long> findProductIdsByMemberId(Long memberId) {
-    String sql = "SELECT productId FROM wishes WHERE memberId = ?";
+  public List<ProductResponseDto> findWishesByMemberId(Long memberId) {
+    String sql = "SELECT \n"
+        + "    w.wishId,\n"
+        + "    w.memberId,\n"
+        + "    w.productId,\n"
+        + "    p.name AS productName,\n"
+        + "    p.price AS productPrice,\n"
+        + "    p.imageUrl AS productImageUrl,\n"
+        + "    p.kakaoApproval AS productKakaoApproval\n"
+        + "FROM wishes AS w\n"
+        + "JOIN products AS p \n"
+        + "    ON p.id = w.productId\n"
+        + "WHERE w.memberId = ?";
 
     return jdbcClient.sql(sql)
         .param(memberId)
-        .query(Long.class)
+        .query((rs, rowNum) -> new ProductResponseDto(
+            rs.getLong("productId"),
+            rs.getString("name"),
+            rs.getInt("price"),
+            rs.getString("imageUrl"),
+            rs.getBoolean("kakaoApproval")
+        ))
         .list();
   }
 

--- a/src/main/java/gift/wish/dto/WishRequestDto.java
+++ b/src/main/java/gift/wish/dto/WishRequestDto.java
@@ -1,0 +1,10 @@
+package gift.wish.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WishRequestDto(
+    @NotNull(message = "상품ID는 반드시 존재해야합니다.")
+    Long productId
+) {
+
+}

--- a/src/main/java/gift/wish/dto/WishResponseDto.java
+++ b/src/main/java/gift/wish/dto/WishResponseDto.java
@@ -1,0 +1,9 @@
+package gift.wish.dto;
+
+public record WishResponseDto(
+    Long wishId,
+    Long memberId,
+    Long productId
+) {
+
+}

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,0 +1,25 @@
+package gift.wish.service;
+
+import gift.product.service.ProductService;
+import gift.wish.dao.WishDao;
+import gift.wish.dto.WishRequestDto;
+import gift.wish.dto.WishResponseDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WishService {
+  private final ProductService productService;
+  private final WishDao wishDao;
+
+  public WishService(ProductService productService, WishDao wishDao) {
+    this.productService = productService;
+    this.wishDao = wishDao;
+  }
+
+  public WishResponseDto createWish(Long memberId, WishRequestDto wishRequestDto) {
+    productService.findProductById(wishRequestDto.productId());
+
+    return wishDao.createWish(memberId, wishRequestDto.productId());
+  }
+
+}

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,9 +1,12 @@
 package gift.wish.service;
 
+import gift.product.dto.ProductResponseDto;
 import gift.product.service.ProductService;
 import gift.wish.dao.WishDao;
 import gift.wish.dto.WishRequestDto;
 import gift.wish.dto.WishResponseDto;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,6 +23,13 @@ public class WishService {
     productService.findProductById(wishRequestDto.productId());
 
     return wishDao.createWish(memberId, wishRequestDto.productId());
+  }
+
+  public List<ProductResponseDto> getWishes(Long memberId) {
+    List<Long> productIds = wishDao.findProductIdsByMemberId(memberId);
+    return productIds.stream()
+        .map(productService::findProductById)
+        .collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -1,5 +1,6 @@
 package gift.wish.service;
 
+import gift.exception.BusinessException;
 import gift.product.dto.ProductResponseDto;
 import gift.product.service.ProductService;
 import gift.wish.dao.WishDao;
@@ -32,4 +33,7 @@ public class WishService {
         .collect(Collectors.toList());
   }
 
+  public void deleteWish(Long memberId, Long productId) {
+    wishDao.deleteWish(memberId, productId);
+  }
 }

--- a/src/main/java/gift/wish/service/WishService.java
+++ b/src/main/java/gift/wish/service/WishService.java
@@ -27,10 +27,7 @@ public class WishService {
   }
 
   public List<ProductResponseDto> getWishes(Long memberId) {
-    List<Long> productIds = wishDao.findProductIdsByMemberId(memberId);
-    return productIds.stream()
-        .map(productService::findProductById)
-        .collect(Collectors.toList());
+   return  wishDao.findWishesByMemberId(memberId);
   }
 
   public void deleteWish(Long memberId, Long productId) {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,9 +10,20 @@ CREATE TABLE products
 
 CREATE TABLE users
 (
-    memberId       BIGINT AUTO_INCREMENT,
+    memberId BIGINT AUTO_INCREMENT,
     email    VARCHAR(255) NOT NULL,
     password VARCHAR(255) NOT NULL,
-    role     VARCHAR(10) NOT NULL DEFAULT 'USER',
-    PRIMARY KEY(memberId)
+    role     VARCHAR(10)  NOT NULL DEFAULT 'USER',
+    PRIMARY KEY (memberId)
+);
+
+CREATE TABLE wishes
+(
+    wishId    BIGINT AUTO_INCREMENT,
+    memberId  BIGINT NOT NULL,
+    productId BIGINT NOT NULL,
+    FOREIGN KEY (memberId) REFERENCES members (memberId) ON DELETE CASCADE,
+    FOREIGN KEY (productId) REFERENCES products (id) ON DELETE CASCADE,
+    PRIMARY KEY (wishId)
+        UNIQUE (memberId, productId)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,8 +22,8 @@ CREATE TABLE wishes
     wishId    BIGINT AUTO_INCREMENT,
     memberId  BIGINT NOT NULL,
     productId BIGINT NOT NULL,
-    FOREIGN KEY (memberId) REFERENCES members (memberId) ON DELETE CASCADE,
+    FOREIGN KEY (memberId) REFERENCES users (memberId) ON DELETE CASCADE,
     FOREIGN KEY (productId) REFERENCES products (id) ON DELETE CASCADE,
-    PRIMARY KEY (wishId)
+    PRIMARY KEY (wishId),
         UNIQUE (memberId, productId)
 );

--- a/src/test/java/gift/controller/WishRestControllerTest.java
+++ b/src/test/java/gift/controller/WishRestControllerTest.java
@@ -1,0 +1,162 @@
+package gift.controller;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gift.product.dto.ProductResponseDto;
+import gift.security.AdminInterceptor;
+import gift.security.LoginUserArgumentResolver;
+import gift.user.JwtTokenProvider;
+import gift.user.domain.Role;
+import gift.user.domain.User;
+import gift.user.service.UserService;
+import gift.wish.controller.WishRestController;
+import gift.wish.dto.WishRequestDto;
+import gift.wish.dto.WishResponseDto;
+import gift.wish.service.WishService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(WishRestController.class)
+public class WishRestControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private WishService wishService;
+
+  @MockitoBean
+  private LoginUserArgumentResolver loginUserArgumentResolver;
+
+  @MockitoBean
+  private JwtTokenProvider jwtTokenProvider;
+
+  @MockitoBean
+  private AdminInterceptor adminInterceptor;
+
+  @MockitoBean
+  private UserService userService;
+
+  @Test
+  void 위시리스트에_상품을_추가할_수_있다() throws Exception {
+    // given
+    User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
+    given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+        .willReturn(mockUser);
+
+    var token = "token";
+    var request = new WishRequestDto(1L);
+    var content = objectMapper.writeValueAsString(request);
+    given(wishService.createWish(any(), any())).willReturn(new WishResponseDto(1L, 1L, 1L));
+
+    // when
+    var actual = createWish(token, content);
+
+    // then
+    assertThat(actual.getStatus()).isEqualTo(HttpStatus.CREATED.value());
+
+    var response = objectMapper.readValue(actual.getContentAsString(), WishResponseDto.class);
+    assertThat(response.productId()).isEqualTo(1L);
+    assertThat(response.memberId()).isEqualTo(1L);
+    assertThat(response.wishId()).isEqualTo(1L);
+  }
+
+  @Test
+  void 위시리스트_상품_목록을_조회할_수_있다() throws Exception {
+    // given
+    User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
+    given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+        .willReturn(mockUser);
+
+    var token = "token";
+    List<ProductResponseDto> expectedProducts = List.of(
+        new ProductResponseDto(1L, "상품1", 10000, "thisisurl", false)
+    );
+    given(wishService.getWishes(any())).willReturn(expectedProducts);
+
+    // when
+    var actual = getWishes(token);
+
+    // then
+    assertThat(actual.getStatus()).isEqualTo(HttpStatus.OK.value());
+
+    var response = objectMapper.readValue(actual.getContentAsString(),
+        objectMapper.getTypeFactory()
+            .constructCollectionType(List.class, ProductResponseDto.class));
+    assertThat(actual.getContentAsString())
+        .contains("\"id\":1")
+        .contains("\"name\":\"상품1\"");
+  }
+
+  @Test
+  void 위시리스트에서_상품을_삭제할_수_있다() throws Exception {
+    // given
+    User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
+    given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
+    given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+        .willReturn(mockUser);
+
+    var token = "token";
+    Long productId = 1L;
+    doNothing().when(wishService).deleteWish(any(), any());
+
+    // when
+    var actual = deleteWish(token, productId);
+
+    // then
+    assertThat(actual.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
+  }
+
+  private MockHttpServletResponse createWish(String token, String content) throws Exception {
+    return mockMvc.perform(
+            post("/api/wishes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .content(content)
+        )
+        .andDo(print())
+        .andReturn()
+        .getResponse();
+  }
+
+  private MockHttpServletResponse getWishes(String token) throws Exception {
+    return mockMvc.perform(
+            get("/api/wishes")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        )
+        .andDo(print())
+        .andReturn()
+        .getResponse();
+  }
+
+  private MockHttpServletResponse deleteWish(String token, Long productId) throws Exception {
+    return mockMvc.perform(
+            delete("/api/wishes/" + productId)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+        )
+        .andDo(print())
+        .andReturn()
+        .getResponse();
+  }
+}

--- a/src/test/java/gift/controller/WishRestControllerTest.java
+++ b/src/test/java/gift/controller/WishRestControllerTest.java
@@ -22,6 +22,7 @@ import gift.wish.dto.WishRequestDto;
 import gift.wish.dto.WishResponseDto;
 import gift.wish.service.WishService;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -56,14 +57,17 @@ public class WishRestControllerTest {
   @MockitoBean
   private UserService userService;
 
-  @Test
-  void 위시리스트에_상품을_추가할_수_있다() throws Exception {
-    // given
+  @BeforeEach
+  void getToken() throws Exception {
     User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
     given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
     given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
         .willReturn(mockUser);
+  }
 
+  @Test
+  void 위시리스트에_상품을_추가할_수_있다() throws Exception {
+    //given
     var token = "token";
     var request = new WishRequestDto(1L);
     var content = objectMapper.writeValueAsString(request);
@@ -84,11 +88,6 @@ public class WishRestControllerTest {
   @Test
   void 위시리스트_상품_목록을_조회할_수_있다() throws Exception {
     // given
-    User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
-    given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
-    given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
-        .willReturn(mockUser);
-
     var token = "token";
     List<ProductResponseDto> expectedProducts = List.of(
         new ProductResponseDto(1L, "상품1", 10000, "thisisurl", false)
@@ -112,11 +111,6 @@ public class WishRestControllerTest {
   @Test
   void 위시리스트에서_상품을_삭제할_수_있다() throws Exception {
     // given
-    User mockUser = new User(1L, "admin@admin.com", "encodedPassword", Role.USER);
-    given(loginUserArgumentResolver.supportsParameter(any())).willReturn(true);
-    given(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
-        .willReturn(mockUser);
-
     var token = "token";
     Long productId = 1L;
     doNothing().when(wishService).deleteWish(any(), any());


### PR DESCRIPTION
안녕하세요 멘토님! 3단계 위시리스트 기능 구현 구현하였습니다!

## 구현사항
### 이전 단계에서 로그인 후 받은 토큰을 사용하여 사용자별 위시 리스트 기능을 구현한다.
- `@LoginUser` 커스텀 어노테이션 생성하여 사용자 정보 자동 주입하였습니다.
- `LoginUserArgumentResolver`에서 Authorization 헤더의 Bearer을 추출한,
- 실제 JWT 토큰에서 email 정보를 추출하여 실제 User 객체 조회하였습니다.

### 위시 리스트에 등록된 상품 목록을 조회할 수 있다. 
- /api/wishes 
- `Post`
### 위시 리스트에 상품을 추가할 수 있다.
- /api/wishes
- `GET`
### 위시 리스트에 담긴 상품을 삭제할 수 있다.
- /api/wishes/{productId}
- `DELETE`
## 고민했던 사항
### 도메인
- 요구사항에 따른 위시리스트는 단순한 책임만을 가지므로 도메인없이 구현하고자 했습니다.
### DB JOIN 사용
- members와 products table에 대해 foreign key를 사용하므로 JOIN을 활용하여 구현해야하나 고민했지만 DAO에서 ProductId 리스트를 조회한 후 ProductService를 이용하였습니다.